### PR TITLE
Added trailing comma in ErrorType enum

### DIFF
--- a/src/ErrorType.cs
+++ b/src/ErrorType.cs
@@ -10,5 +10,5 @@ public enum ErrorType
     Validation,
     Conflict,
     NotFound,
-    NotAuthorized
+    NotAuthorized,
 }


### PR DESCRIPTION
Fixed build error Use trailing comma in multi-line initializers