### PR TITLE
Added property IsSuccess to ErrorOr<TValue>

### DIFF
--- a/src/ErrorOr.cs
+++ b/src/ErrorOr.cs
@@ -22,6 +22,11 @@ public record struct ErrorOr<TValue> : IErrorOr
     public bool IsError { get; }
 
     /// <summary>
+    /// Gets a value indicating whether the state is success (error didn't happen).
+    /// </summary>
+    public bool IsSuccess { get => !IsError; }
+
+    /// <summary>
     /// Gets the list of errors. If the state is not error, the list will contain a single error representing the state.
     /// </summary>
     public List<Error> Errors => IsError ? _errors! : new List<Error> { NoErrors };


### PR DESCRIPTION
**This pull request makes following changes:**
There is request (#49) that asks to add IsSuccess Property to the ErrorOr<TValue>. I added the property that is reversal of IsError.
- closes #49