### PR TITLE
Added Forbidden as Error

### DIFF
--- a/src/Error.cs
+++ b/src/Error.cs
@@ -94,6 +94,16 @@ public readonly record struct Error
         new(code, description, ErrorType.Unauthorized);
 
     /// <summary>
+    /// Creates an <see cref="Error"/> of type <see cref="ErrorType.Forbidden"/> from a code and description.
+    /// </summary>
+    /// <param name="code">The unique error code.</param>
+    /// <param name="description">The error description.</param>
+    public static Error Forbidden(
+        string code = "General.Forbidden",
+        string description = "An 'Forbidden' error has occurred.") =>
+        new(code, description, ErrorType.Forbidden);
+
+    /// <summary>
     /// Creates an <see cref="Error"/> with the given numeric <paramref name="type"/>,
     /// <paramref name="code"/>, and <paramref name="description"/>.
     /// </summary>

--- a/src/ErrorType.cs
+++ b/src/ErrorType.cs
@@ -11,4 +11,5 @@ public enum ErrorType
     Conflict,
     NotFound,
     Unauthorized,
+    Forbidden,
 }

--- a/tests/ErrorTests.cs
+++ b/tests/ErrorTests.cs
@@ -69,6 +69,16 @@ public class ErrorTests
     }
 
     [Fact]
+    public void CreateError_WhenForbiddenError_ShouldHaveErrorTypeUnauthorized()
+    {
+        // Act
+        Error error = Error.Forbidden(ErrorCode, ErrorDescription);
+
+        // Assert
+        ValidateError(error, expectedErrorType: ErrorType.Forbidden);
+    }
+
+    [Fact]
     public void CreateError_WhenCustomType_ShouldHaveCustomErrorType()
     {
         // Act


### PR DESCRIPTION
This PR introduces a new error type called "Forbidden" to the project. The "Forbidden" error type is useful when we must represent situations where an action or request is denied due to lack of permissions or authorization.