### PR TITLE
ErrorOr<TValue> and Error now behave like Value Objects

### DIFF
--- a/src/Error.cs
+++ b/src/Error.cs
@@ -137,4 +137,67 @@ public readonly record struct Error
         NumericType = (int)type;
         Metadata = metadata;
     }
+
+    public bool Equals(Error other)
+    {
+        if (Type != other.Type ||
+            NumericType != other.NumericType ||
+            Code != other.Code ||
+            Description != other.Description)
+        {
+            return false;
+        }
+
+        if (Metadata is null)
+        {
+            return other.Metadata is null;
+        }
+
+        return other.Metadata is not null && CompareMetadata(Metadata, other.Metadata);
+    }
+
+    private static bool CompareMetadata(Dictionary<string, object> metadata, Dictionary<string, object> otherMetadata)
+    {
+        if (ReferenceEquals(metadata, otherMetadata))
+        {
+            return true;
+        }
+
+        if (metadata.Count != otherMetadata.Count)
+        {
+            return false;
+        }
+
+        foreach (var keyValuePair in metadata)
+        {
+            if (!otherMetadata.TryGetValue(keyValuePair.Key, out var otherValue) ||
+                !keyValuePair.Value.Equals(otherValue))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public override int GetHashCode() =>
+        Metadata is null ? HashCode.Combine(Code, Description, Type, NumericType) : ComposeHashCode();
+
+    private int ComposeHashCode()
+    {
+#pragma warning disable SA1129 // HashCode needs to be instantiated this way
+        var hashCode = new HashCode();
+#pragma warning restore SA1129
+        hashCode.Add(Code);
+        hashCode.Add(Description);
+        hashCode.Add(Type);
+        hashCode.Add(NumericType);
+        foreach (var keyValuePair in Metadata!)
+        {
+            hashCode.Add(keyValuePair.Key);
+            hashCode.Add(keyValuePair.Value);
+        }
+
+        return hashCode.ToHashCode();
+    }
 }

--- a/src/ErrorOr.Equality.cs
+++ b/src/ErrorOr.Equality.cs
@@ -1,0 +1,59 @@
+namespace ErrorOr;
+
+public readonly partial record struct ErrorOr<TValue>
+{
+    public bool Equals(ErrorOr<TValue> other)
+    {
+        if (!IsError)
+        {
+            return !other.IsError && EqualityComparer<TValue>.Default.Equals(_value, other._value);
+        }
+
+        return other.IsError && CheckIfErrorsAreEqual(_errors, other._errors);
+    }
+
+    private static bool CheckIfErrorsAreEqual(List<Error> errors1, List<Error> errors2)
+    {
+        // This method is currently implemented with strict ordering in mind, so the errors
+        // of the two lists need to be in the exact same order.
+        // This avoids allocating a hash set. We could provide a dedicated EqualityComparer for
+        // ErrorOr<TValue> when arbitrary orders should be supported.
+        if (ReferenceEquals(errors1, errors2))
+        {
+            return true;
+        }
+
+        if (errors1.Count != errors2.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < errors1.Count; i++)
+        {
+            if (!errors1[i].Equals(errors2[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public override int GetHashCode()
+    {
+        if (!IsError)
+        {
+            return _value.GetHashCode();
+        }
+
+#pragma warning disable SA1129 // HashCode needs to be instantiated this way
+        var hashCode = new HashCode();
+#pragma warning restore SA1129
+        for (var i = 0; i < _errors.Count; i++)
+        {
+            hashCode.Add(_errors[i]);
+        }
+
+        return hashCode.ToHashCode();
+    }
+}

--- a/src/ErrorOr.cs
+++ b/src/ErrorOr.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace ErrorOr;
 
 /// <summary>
@@ -19,6 +21,10 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// <summary>
     /// Gets a value indicating whether the state is error.
     /// </summary>
+    [MemberNotNullWhen(true, nameof(_errors))]
+    [MemberNotNullWhen(true, nameof(Errors))]
+    [MemberNotNullWhen(false, nameof(Value))]
+    [MemberNotNullWhen(false, nameof(_value))]
     public bool IsError { get; }
 
     /// <summary>

--- a/src/ErrorOr.csproj
+++ b/src/ErrorOr.csproj
@@ -28,4 +28,16 @@
     <AdditionalFiles Include="Stylecop.json" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference
+      Include="Microsoft.Bcl.HashCode"
+      Version="1.1.1"
+      Condition="'$(TargetFramework)' == 'netstandard2.0'"
+    />
+    <PackageReference Include="Nullable" Version="1.3.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/tests/Error.EqualityTests.cs
+++ b/tests/Error.EqualityTests.cs
@@ -1,0 +1,98 @@
+﻿using ErrorOr;
+using FluentAssertions;
+
+namespace Tests;
+
+public sealed class ErrorEqualityTests
+{
+    public static readonly TheoryData<string, string, int, Dictionary<string, object>?> ValidData =
+        new ()
+        {
+            { "CodeA", "DescriptionA", 1, null },
+            { "CodeB", "DescriptionB", 3215, new Dictionary<string, object> { { "foo", "bar" }, { "baz", "qux" } } },
+        };
+
+    public static readonly TheoryData<Error, Error> DifferentInstances =
+        new ()
+        {
+            { Error.Failure(), Error.Forbidden() },
+            { Error.NotFound(), Error.NotFound(metadata: new Dictionary<string, object> { ["Foo"] = "Bar" }) },
+            { Error.Unexpected(metadata: new Dictionary<string, object> { ["baz"] = "qux" }), Error.Unexpected() },
+            {
+                Error.Failure(metadata: new Dictionary<string, object> { ["baz"] = "qux" }),
+                Error.Failure(metadata: new Dictionary<string, object> { ["Foo"] = "Bar", ["baz"] = "qux" })
+            },
+            {
+                Error.Failure(metadata: new Dictionary<string, object> { ["baz"] = "qux" }),
+                Error.Failure(metadata: new Dictionary<string, object> { ["baz"] = "gorge" })
+            },
+        };
+
+    [Theory]
+    [MemberData(nameof(ValidData))]
+    public void Equals_WhenTwoInstancesHaveTheSameValues_ShouldReturnTrue(
+        string code,
+        string description,
+        int numericType,
+        Dictionary<string, object>? metadata)
+    {
+        var error1 = Error.Custom(numericType, code, description, metadata);
+        var clonedDictionary = metadata is null ? null : new Dictionary<string, object>(metadata);
+        var error2 = Error.Custom(numericType, code, description, clonedDictionary);
+
+        var result = error1.Equals(error2);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_WhenTwoInstancesHaveTheSameMetadataInstanceAndPropertyValues_ShouldReturnTrue()
+    {
+        var metadata = new Dictionary<string, object> { { "foo", "bar" } };
+        var error1 = Error.Custom(1, "Code", "Description", metadata);
+        var error2 = Error.Custom(1, "Code", "Description", metadata);
+
+        var result = error1.Equals(error2);
+
+        result.Should().BeTrue();
+    }
+
+    [Theory]
+    [MemberData(nameof(DifferentInstances))]
+    public void Equals_WhenTwoInstancesHaveDifferentValues_ShouldReturnFalse(Error error1, Error error2)
+    {
+        var result = error1.Equals(error2);
+
+        result.Should().BeFalse();
+    }
+
+    [Theory]
+    [MemberData(nameof(ValidData))]
+    public void GetHashCode_WhenTwoInstancesHaveSameValues_ShouldReturnSameHashCode(
+        string code,
+        string description,
+        int numericType,
+        Dictionary<string, object>? metadata)
+    {
+        var error1 = Error.Custom(numericType, code, description, metadata);
+        var clonedDictionary = metadata is null ? null : new Dictionary<string, object>(metadata);
+        var error2 = Error.Custom(numericType, code, description, clonedDictionary);
+
+        var hashCode1 = error1.GetHashCode();
+        var hashCode2 = error2.GetHashCode();
+
+        hashCode1.Should().Be(hashCode2);
+    }
+
+    [Theory]
+    [MemberData(nameof(DifferentInstances))]
+    public void GetHashCode_WhenTwoInstancesHaveDifferentValues_ShouldReturnDifferentHashCodes(
+        Error error1,
+        Error error2)
+    {
+        var hashCode1 = error1.GetHashCode();
+        var hashCode2 = error2.GetHashCode();
+
+        hashCode1.Should().NotBe(hashCode2);
+    }
+}

--- a/tests/ErrorOr.EqualityTests.cs
+++ b/tests/ErrorOr.EqualityTests.cs
@@ -1,0 +1,181 @@
+﻿using ErrorOr;
+using FluentAssertions;
+
+namespace Tests;
+
+public sealed class ErrorOrEqualityTests
+{
+    // ReSharper disable once NotAccessedPositionalProperty.Local -- we require this property for these tests
+    private record Person(string Name);
+
+    public static readonly TheoryData<Error[], Error[]> DifferentErrors =
+        new ()
+        {
+            {
+                // Different number of entries
+                new[]
+                {
+                    Error.Validation("User.Name", "Name is too short"),
+                },
+                new[]
+                {
+                    Error.Validation("User.Name", "Name is too short"),
+                    Error.Validation("User.Age", "User is too young"),
+                }
+            },
+            {
+                // Different errors
+                new[]
+                {
+                    Error.Validation("User.Name", "Name is too short"),
+                },
+                new[]
+                {
+                    Error.Validation("User.Age", "User is too young"),
+                }
+            },
+        };
+
+    public static readonly TheoryData<string> Names = new () { "Amichai", "feO2x" };
+
+    public static readonly TheoryData<string, string> DifferentNames =
+        new () { { "Amichai", "feO2x" }, { "Tyrion", "Cersei" } };
+
+    [Fact]
+    public void Equals_WhenTwoInstancesHaveTheSameErrorsCollection_ShouldReturnTrue()
+    {
+        var errors = new List<Error>
+        {
+            Error.Validation("User.Name", "Name is too short"),
+            Error.Validation("User.Age", "User is too young"),
+        };
+        ErrorOr<Person> errorOrPerson1 = errors;
+        ErrorOr<Person> errorOrPerson2 = errors;
+
+        var result = errorOrPerson1.Equals(errorOrPerson2);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_WhenTwoInstancesHaveDifferentErrorCollectionsWithSameErrors_ShouldReturnTrue()
+    {
+        var errors1 = new[]
+        {
+            Error.Validation("User.Name", "Name is too short"),
+            Error.Validation("User.Age", "User is too young"),
+        };
+        var errors2 = new[]
+        {
+            Error.Validation("User.Name", "Name is too short"),
+            Error.Validation("User.Age", "User is too young"),
+        };
+        ErrorOr<Person> errorOrPerson1 = errors1;
+        ErrorOr<Person> errorOrPerson2 = errors2;
+
+        var result = errorOrPerson1.Equals(errorOrPerson2);
+
+        result.Should().BeTrue();
+    }
+
+    [Theory]
+    [MemberData(nameof(DifferentErrors))]
+    public void Equals_WhenTwoInstancesHaveDifferentErrors_ShouldReturnFalse(Error[] errors1, Error[] errors2)
+    {
+        ErrorOr<Person> errorOrPerson1 = errors1;
+        ErrorOr<Person> errorOrPerson2 = errors2;
+
+        var result = errorOrPerson1.Equals(errorOrPerson2);
+
+        result.Should().BeFalse();
+    }
+
+    [Theory]
+    [MemberData(nameof(Names))]
+    public void Equals_WhenTwoInstancesHaveEqualValues_ShouldReturnTrue(string name)
+    {
+        ErrorOr<Person> errorOrPerson1 = new Person(name);
+        ErrorOr<Person> errorOrPerson2 = new Person(name);
+
+        var result = errorOrPerson1.Equals(errorOrPerson2);
+
+        result.Should().BeTrue();
+    }
+
+    [Theory]
+    [MemberData(nameof(DifferentNames))]
+    public void Equals_WhenTwoInstancesHaveDifferentValues_ShouldReturnFalse(string name1, string name2)
+    {
+        ErrorOr<Person> errorOrPerson1 = new Person(name1);
+        ErrorOr<Person> errorOrPerson2 = new Person(name2);
+
+        var result = errorOrPerson1.Equals(errorOrPerson2);
+
+        result.Should().BeFalse();
+    }
+
+    [Theory]
+    [MemberData(nameof(Names))]
+    public void GetHashCode_WhenTwoInstancesHaveEqualValues_ShouldReturnSameHashCode(string name)
+    {
+        ErrorOr<Person> errorOrPerson1 = new Person(name);
+        ErrorOr<Person> errorOrPerson2 = new Person(name);
+
+        var hashCode1 = errorOrPerson1.GetHashCode();
+        var hashCode2 = errorOrPerson2.GetHashCode();
+
+        hashCode1.Should().Be(hashCode2);
+    }
+
+    [Theory]
+    [MemberData(nameof(DifferentNames))]
+    public void GetHashCode_WhenTwoInstanceHaveDifferentValues_ShouldReturnDifferentHashCodes(
+        string name1,
+        string name2)
+    {
+        ErrorOr<Person> errorOrPerson1 = new Person(name1);
+        ErrorOr<Person> errorOrPerson2 = new Person(name2);
+
+        var hashCode1 = errorOrPerson1.GetHashCode();
+        var hashCode2 = errorOrPerson2.GetHashCode();
+
+        hashCode1.Should().NotBe(hashCode2);
+    }
+
+    [Fact]
+    public void GetHashCode_WhenTwoInstancesHaveEqualErrors_ShouldReturnSameHashCode()
+    {
+        var errors1 = new[]
+        {
+            Error.Validation("User.Name", "Name is too short"),
+            Error.Validation("User.Age", "User is too young"),
+        };
+        var errors2 = new[]
+        {
+            Error.Validation("User.Name", "Name is too short"),
+            Error.Validation("User.Age", "User is too young"),
+        };
+        ErrorOr<Person> errorOrPerson1 = errors1;
+        ErrorOr<Person> errorOrPerson2 = errors2;
+
+        var hashCode1 = errorOrPerson1.GetHashCode();
+        var hashCode2 = errorOrPerson2.GetHashCode();
+
+        hashCode1.Should().Be(hashCode2);
+    }
+
+    [Theory]
+    [MemberData(nameof(DifferentErrors))]
+    public void GetHashCode_WhenTwoInstancesHaveDifferentErrors_ShouldReturnDifferentHashCodes(
+        Error[] errors1,
+        Error[] errors2)
+    {
+        ErrorOr<Person> errorOrPerson1 = errors1;
+        ErrorOr<Person> errorOrPerson2 = errors2;
+
+        var hashCode1 = errorOrPerson1.GetHashCode();
+        var hashCode2 = errorOrPerson2.GetHashCode();
+
+        hashCode1.Should().NotBe(hashCode2);
+    }
+}


### PR DESCRIPTION
This PR fixes https://github.com/amantinband/error-or/issues/85 by explicitly implementing `Equals` and `GetHashCode` for the `ErrorOr<TValue>` and `Error` record structs. In them, we perform a deep comparison for the errors list and metadata dictionary, respectively. I also include unit tests that cover these implementations.

I introduced the runtime dependency [Microsoft.Bcl.HashCode](https://www.nuget.org/packages/Microsoft.Bcl.HashCode) so that I can use the `HashCode` struct both in .NET Standard 2.0 and .NET 6. If we do not want this dependency for .NET Standard 2.0, we should copy over the source code of `HashCode` - please let me know how you want to deal with this.

I also introduced [Nullable](https://www.nuget.org/packages/Nullable), but this is not a runtime dependency. It is simply there so that I can use the `MemberNotNullWhenAttribute` in .NET Standard 2.0, too. This helps Roslyn with tracking whether `_value` or `_errors` is null when `IsErrors` was called beforehand in `ErrorOr<TValue>`.