### PR TITLE
Memory Optimizations for ErrorOr<TValue>

### DIFF
--- a/src/ErrorOr.cs
+++ b/src/ErrorOr.cs
@@ -8,14 +8,6 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     private readonly TValue? _value = default;
     private readonly List<Error>? _errors = null;
 
-    private static readonly Error NoFirstError = Error.Unexpected(
-        code: "ErrorOr.NoFirstError",
-        description: "First error cannot be retrieved from a successful ErrorOr.");
-
-    private static readonly Error NoErrors = Error.Unexpected(
-        code: "ErrorOr.NoErrors",
-        description: "Error list cannot be retrieved from a successful ErrorOr.");
-
     /// <summary>
     /// Gets a value indicating whether the state is error.
     /// </summary>
@@ -24,12 +16,12 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// <summary>
     /// Gets the list of errors. If the state is not error, the list will contain a single error representing the state.
     /// </summary>
-    public List<Error> Errors => IsError ? _errors! : new List<Error> { NoErrors };
+    public List<Error> Errors => IsError ? _errors! : KnownErrors.CachedNoErrorsList;
 
     /// <summary>
     /// Gets the list of errors. If the state is not error, the list will be empty.
     /// </summary>
-    public List<Error> ErrorsOrEmptyList => IsError ? _errors! : new();
+    public List<Error> ErrorsOrEmptyList => IsError ? _errors! : KnownErrors.CachedEmptyErrorsList;
 
     /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> from a list of errors.
@@ -53,7 +45,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
         {
             if (!IsError)
             {
-                return NoFirstError;
+                return KnownErrors.NoFirstError;
             }
 
             return _errors![0];

--- a/src/KnownErrors.cs
+++ b/src/KnownErrors.cs
@@ -1,0 +1,16 @@
+﻿namespace ErrorOr;
+
+internal static class KnownErrors
+{
+    public static Error NoFirstError { get; } = Error.Unexpected(
+        code: "ErrorOr.NoFirstError",
+        description: "First error cannot be retrieved from a successful ErrorOr.");
+
+    public static Error NoErrors { get; } = Error.Unexpected(
+        code: "ErrorOr.NoErrors",
+        description: "Error list cannot be retrieved from a successful ErrorOr.");
+
+    public static List<Error> CachedNoErrorsList { get; } = new (1) { NoErrors };
+
+    public static List<Error> CachedEmptyErrorsList { get; } = new (0);
+}


### PR DESCRIPTION
This PR fixes https://github.com/amantinband/error-or/issues/98 and introduces a new class called 'KnownErrors' which contains the NoFirstError and NoErrors instances that previously resided in `ErrorOr<TValue>`. With this change, they will not reside in memory several times during runtime (once for each type `TValue` is resolved to). Furthermore, I cached two lists so that they won't be instantiated every time the `Errors` and `ErrorsOrEmptyList` property is called.