### PR TITLE
Exceptions for invalid use - review and extensions

### DIFF
--- a/src/ErrorOr/EmptyErrors.cs
+++ b/src/ErrorOr/EmptyErrors.cs
@@ -1,0 +1,6 @@
+﻿namespace ErrorOr;
+
+internal static class EmptyErrors
+{
+    public static List<Error> Instance { get; } = [];
+}

--- a/src/ErrorOr/ErrorOr.ImplicitConverters.cs
+++ b/src/ErrorOr/ErrorOr.ImplicitConverters.cs
@@ -23,6 +23,11 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// </summary>
     public static implicit operator ErrorOr<TValue>(List<Error> errors)
     {
+        if (errors is null)
+        {
+            throw new ArgumentNullException(nameof(errors));
+        }
+
         if (errors.Count == 0)
         {
             throw new InvalidOperationException("Cannot create an ErrorOr<TValue> from an empty list of errors. Provide at least one error.");
@@ -36,6 +41,11 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// </summary>
     public static implicit operator ErrorOr<TValue>(Error[] errors)
     {
+        if (errors is null)
+        {
+            throw new ArgumentNullException(nameof(errors));
+        }
+
         if (errors.Length == 0)
         {
             throw new InvalidOperationException("Cannot create an ErrorOr<TValue> from an empty array of errors. Provide at least one error.");

--- a/src/ErrorOr/ErrorOr.ImplicitConverters.cs
+++ b/src/ErrorOr/ErrorOr.ImplicitConverters.cs
@@ -22,7 +22,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// Creates an <see cref="ErrorOr{TValue}"/> from a list of errors.
     /// </summary>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>
-    /// <exception cref="InvalidOperationException">Thrown when <paramref name="errors" /> is an empty list.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="errors" /> is an empty list.</exception>
     public static implicit operator ErrorOr<TValue>(List<Error> errors)
     {
         if (errors is null)
@@ -32,7 +32,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
 
         if (errors.Count == 0)
         {
-            throw new InvalidOperationException("Cannot create an ErrorOr<TValue> from an empty list of errors. Provide at least one error.");
+            throw new ArgumentException("Cannot create an ErrorOr<TValue> from an empty list of errors. Provide at least one error.", nameof(errors));
         }
 
         return new ErrorOr<TValue>(errors);
@@ -42,7 +42,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// Creates an <see cref="ErrorOr{TValue}"/> from a list of errors.
     /// </summary>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>
-    /// <exception cref="InvalidOperationException">Thrown when <paramref name="errors" /> is an empty array.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="errors" /> is an empty array.</exception>
     public static implicit operator ErrorOr<TValue>(Error[] errors)
     {
         if (errors is null)
@@ -52,7 +52,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
 
         if (errors.Length == 0)
         {
-            throw new InvalidOperationException("Cannot create an ErrorOr<TValue> from an empty array of errors. Provide at least one error.");
+            throw new ArgumentException("Cannot create an ErrorOr<TValue> from an empty array of errors. Provide at least one error.", nameof(errors));
         }
 
         return new ErrorOr<TValue>(errors.ToList());

--- a/src/ErrorOr/ErrorOr.ImplicitConverters.cs
+++ b/src/ErrorOr/ErrorOr.ImplicitConverters.cs
@@ -21,6 +21,8 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> from a list of errors.
     /// </summary>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when <paramref name="errors" /> is an empty list.</exception>
     public static implicit operator ErrorOr<TValue>(List<Error> errors)
     {
         if (errors is null)
@@ -39,6 +41,8 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> from a list of errors.
     /// </summary>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when <paramref name="errors" /> is an empty array.</exception>
     public static implicit operator ErrorOr<TValue>(Error[] errors)
     {
         if (errors is null)

--- a/src/ErrorOr/ErrorOr.ToErrorOrExtensions.cs
+++ b/src/ErrorOr/ErrorOr.ToErrorOrExtensions.cs
@@ -19,10 +19,12 @@ public static partial class ErrorOrExtensions
     }
 
     /// <summary>
-    /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given <paramref name="error"/>.
+    /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given <paramref name="errors"/>.
     /// </summary>
-    public static ErrorOr<TValue> ToErrorOr<TValue>(this List<Error> error)
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when <paramref name="errors" /> is an empty list.</exception>
+    public static ErrorOr<TValue> ToErrorOr<TValue>(this List<Error> errors)
     {
-        return error;
+        return errors;
     }
 }

--- a/src/ErrorOr/ErrorOr.ToErrorOrExtensions.cs
+++ b/src/ErrorOr/ErrorOr.ToErrorOrExtensions.cs
@@ -22,7 +22,7 @@ public static partial class ErrorOrExtensions
     /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given <paramref name="errors"/>.
     /// </summary>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>
-    /// <exception cref="InvalidOperationException">Thrown when <paramref name="errors" /> is an empty list.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="errors" /> is an empty list.</exception>
     public static ErrorOr<TValue> ToErrorOr<TValue>(this List<Error> errors)
     {
         return errors;
@@ -32,7 +32,7 @@ public static partial class ErrorOrExtensions
     /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given <paramref name="errors"/>.
     /// </summary>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>
-    /// <exception cref="InvalidOperationException">Thrown when <paramref name="errors" /> is an empty array.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="errors" /> is an empty array.</exception>
     public static ErrorOr<TValue> ToErrorOr<TValue>(this Error[] errors)
     {
         return errors;

--- a/src/ErrorOr/ErrorOr.ToErrorOrExtensions.cs
+++ b/src/ErrorOr/ErrorOr.ToErrorOrExtensions.cs
@@ -27,4 +27,14 @@ public static partial class ErrorOrExtensions
     {
         return errors;
     }
+
+    /// <summary>
+    /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given <paramref name="errors"/>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when <paramref name="errors" /> is an empty array.</exception>
+    public static ErrorOr<TValue> ToErrorOr<TValue>(this Error[] errors)
+    {
+        return errors;
+    }
 }

--- a/src/ErrorOr/ErrorOr.cs
+++ b/src/ErrorOr/ErrorOr.cs
@@ -46,12 +46,12 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// <summary>
     /// Gets the list of errors. If the state is not error, the list will contain a single error representing the state.
     /// </summary>
-    public List<Error> Errors => IsError ? _errors! : throw new InvalidOperationException("The Errors property cannot be accessed when no errors have been recorded. Check IsError before accessing Errors.");
+    public List<Error> Errors => IsError ? _errors : throw new InvalidOperationException("The Errors property cannot be accessed when no errors have been recorded. Check IsError before accessing Errors.");
 
     /// <summary>
     /// Gets the list of errors. If the state is not error, the list will be empty.
     /// </summary>
-    public List<Error> ErrorsOrEmptyList => IsError ? _errors! : [];
+    public List<Error> ErrorsOrEmptyList => IsError ? _errors : EmptyErrors.Instance;
 
     /// <summary>
     /// Gets the value.
@@ -70,7 +70,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
                 throw new InvalidOperationException("The FirstError property cannot be accessed when no errors have been recorded. Check IsError before accessing FirstError.");
             }
 
-            return _errors![0];
+            return _errors[0];
         }
     }
 

--- a/src/ErrorOr/ErrorOr.cs
+++ b/src/ErrorOr/ErrorOr.cs
@@ -22,19 +22,16 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     private ErrorOr(Error error)
     {
         _errors = [error];
-        IsError = true;
     }
 
     private ErrorOr(List<Error> errors)
     {
         _errors = errors;
-        IsError = true;
     }
 
     private ErrorOr(TValue value)
     {
         _value = value;
-        IsError = false;
     }
 
     /// <summary>
@@ -44,7 +41,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     [MemberNotNullWhen(true, nameof(Errors))]
     [MemberNotNullWhen(false, nameof(Value))]
     [MemberNotNullWhen(false, nameof(_value))]
-    public bool IsError { get; }
+    public bool IsError => _errors is not null;
 
     /// <summary>
     /// Gets the list of errors. If the state is not error, the list will contain a single error representing the state.

--- a/src/ErrorOr/ErrorOr.cs
+++ b/src/ErrorOr/ErrorOr.cs
@@ -14,6 +14,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// <summary>
     /// Prevents a default <see cref="ErrorOr"/> struct from being created.
     /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when this method is called.</exception>
     public ErrorOr()
     {
         throw new InvalidOperationException("Default construction of ErrorOr<TValue> is invalid. Please use provided factory methods to instantiate.");
@@ -46,6 +47,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// <summary>
     /// Gets the list of errors. If the state is not error, the list will contain a single error representing the state.
     /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when no errors are present.</exception>
     public List<Error> Errors => IsError ? _errors : throw new InvalidOperationException("The Errors property cannot be accessed when no errors have been recorded. Check IsError before accessing Errors.");
 
     /// <summary>
@@ -56,6 +58,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// <summary>
     /// Gets the value.
     /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when no value is present.</exception>
     public TValue Value
     {
         get
@@ -72,6 +75,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// <summary>
     /// Gets the first error.
     /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when no errors are present.</exception>
     public Error FirstError
     {
         get

--- a/src/ErrorOr/ErrorOr.cs
+++ b/src/ErrorOr/ErrorOr.cs
@@ -56,7 +56,18 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// <summary>
     /// Gets the value.
     /// </summary>
-    public TValue Value => _value!;
+    public TValue Value
+    {
+        get
+        {
+            if (IsError)
+            {
+                throw new InvalidOperationException("The Value property cannot be accessed when errors have been recorded. Check IsError before accessing Value.");
+            }
+
+            return _value;
+        }
+    }
 
     /// <summary>
     /// Gets the first error.

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -364,7 +364,9 @@ public class ErrorOrInstantiationTests
         Func<ErrorOr<int>> errorOrInt = () => new List<Error>();
 
         // Assert
-        errorOrInt.Should().ThrowExactly<InvalidOperationException>();
+        var exception = errorOrInt.Should().ThrowExactly<ArgumentException>().Which;
+        exception.Message.Should().Be("Cannot create an ErrorOr<TValue> from an empty list of errors. Provide at least one error. (Parameter 'errors')");
+        exception.ParamName.Should().Be("errors");
     }
 
     [Fact]
@@ -374,7 +376,9 @@ public class ErrorOrInstantiationTests
         Func<ErrorOr<int>> errorOrInt = () => Array.Empty<Error>();
 
         // Assert
-        errorOrInt.Should().ThrowExactly<InvalidOperationException>();
+        var exception = errorOrInt.Should().ThrowExactly<ArgumentException>().Which;
+        exception.Message.Should().Be("Cannot create an ErrorOr<TValue> from an empty array of errors. Provide at least one error. (Parameter 'errors')");
+        exception.ParamName.Should().Be("errors");
     }
 
     [Fact]

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -376,4 +376,22 @@ public class ErrorOrInstantiationTests
         // Assert
         errorOrInt.Should().ThrowExactly<InvalidOperationException>();
     }
+
+    [Fact]
+    public void CreateErrorOr_WhenNullIsPassedAsErrorsList_ShouldThrowArgumentNullException()
+    {
+        Func<ErrorOr<int>> act = () => default(List<Error>)!;
+
+        act.Should().ThrowExactly<ArgumentNullException>()
+           .And.ParamName.Should().Be("errors");
+    }
+
+    [Fact]
+    public void CreateErrorOr_WhenNullIsPassedAsErrorsArray_ShouldThrowArgumentNullException()
+    {
+        Func<ErrorOr<int>> act = () => default(Error[])!;
+
+        act.Should().ThrowExactly<ArgumentNullException>()
+           .And.ParamName.Should().Be("errors");
+    }
 }

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -144,17 +144,18 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
-    public void CreateFromErrorList_WhenAccessingValue_ShouldReturnDefault()
+    public void CreateFromErrorList_WhenAccessingValue_ShouldThrowInvalidOperationException()
     {
         // Arrange
         List<Error> errors = new() { Error.Validation("User.Name", "Name is too short") };
         ErrorOr<Person> errorOrPerson = ErrorOr<Person>.From(errors);
 
         // Act
-        Person value = errorOrPerson.Value;
+        var act = () => errorOrPerson.Value;
 
         // Assert
-        value.Should().Be(default);
+        act.Should().Throw<InvalidOperationException>()
+           .And.Message.Should().Be("The Value property cannot be accessed when errors have been recorded. Check IsError before accessing Value.");
     }
 
     [Fact]
@@ -247,16 +248,17 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
-    public void ImplicitCastError_WhenAccessingValue_ShouldReturnDefault()
+    public void ImplicitCastError_WhenAccessingValue_ShouldThrowInvalidOperationException()
     {
         // Arrange
         ErrorOr<Person> errorOrPerson = Error.Validation("User.Name", "Name is too short");
 
         // Act
-        Person value = errorOrPerson.Value;
+        var act = () => errorOrPerson.Value;
 
         // Assert
-        value.Should().Be(default);
+        act.Should().Throw<InvalidOperationException>()
+           .And.Message.Should().Be("The Value property cannot be accessed when errors have been recorded. Check IsError before accessing Value.");
     }
 
     [Fact]

--- a/tests/ErrorOr/ErrorOr.ToErrorOrTests.cs
+++ b/tests/ErrorOr/ErrorOr.ToErrorOrTests.cs
@@ -46,4 +46,15 @@ public class ToErrorOrTests
         result.IsError.Should().BeTrue();
         result.Errors.Should().BeEquivalentTo(errors);
     }
+
+    [Fact]
+    public void ArrayOfErrorsToErrorOr_WhenAccessingErrors_ShouldReturnSimilarErrors()
+    {
+        Error[] errors = [Error.Unauthorized(), Error.Validation()];
+
+        ErrorOr<int> result = errors.ToErrorOr<int>();
+
+        result.IsError.Should().BeTrue();
+        result.Errors.Should().Equal(errors);
+    }
 }


### PR DESCRIPTION
Hey Amichai,

I reviewed your exception PR and would suggest the following changes:

- `IsError` is now a computed property. This removes 8 bits for the boolean value from the struct which leads to less execution time when copying by value. The sole indicator is now `_errors` being null.
- I introduced a cached empty list for `ErrorsOrEmptyList`. This prevents allocating a new list on every property call where no errors are present.
- The `Value` property will now throw an `InvalidOperationException` when errors are present. This behavior is now in line with the behavior of the `Errors` or `FirstError` property.
- I changed the `InvalidOperationException` thrown in the implicit conversion methods to an `ArgumentException` - this is the usual exception that callers would expect when invalid parameters are passed in.
- I added a `ToErrorOr` extension method for error arrays - we did not have this one beforehand, only for lists.
- I removed the unnecessary null-forgiving operator uses in `ErrorOr<TValue>`. The C# compiler will comprehend that a field is not null according to the `MemberNotNullWhenAttribute` instances applied to `IsError`.
- I added additional XML exception comments for improved dev experience.

Feel free to cherry-pick these features as you see fit.