### PR TITLE
Add ToErrorOrAsync extension method

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,8 +296,16 @@ public ErrorOr<int> MultipleErrorsToErrorOr()
 
 ## Using The `ToErrorOr` Extension Method
 
+### Values
+
 ```cs
 ErrorOr<int> result = 5.ToErrorOr();
+ErrorOr<int> result = await Task.FromResult(5).ToErrorOrAsync();
+```
+
+### Errors
+
+```cs
 ErrorOr<int> result = Error.Unexpected().ToErrorOr<int>();
 ErrorOr<int> result = new[] { Error.Validation(), Error.Validation() }.ToErrorOr<int>();
 ```

--- a/src/ErrorOr/ErrorOr.ToErrorOrExtensions.cs
+++ b/src/ErrorOr/ErrorOr.ToErrorOrExtensions.cs
@@ -11,6 +11,14 @@ public static partial class ErrorOrExtensions
     }
 
     /// <summary>
+    /// Creates an <see cref="ErrorOr{TValue}"/> instance with the result of the given <see cref="Task{TValue}"/>.
+    /// </summary>
+    public static async Task<ErrorOr<TValue>> ToErrorOrAsync<TValue>(this Task<TValue> value)
+    {
+        return await value;
+    }
+
+    /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given <paramref name="error"/>.
     /// </summary>
     public static ErrorOr<TValue> ToErrorOr<TValue>(this Error error)

--- a/tests/ErrorOr/ErrorOr.ToErrorOrTests.cs
+++ b/tests/ErrorOr/ErrorOr.ToErrorOrTests.cs
@@ -20,6 +20,21 @@ public class ToErrorOrTests
     }
 
     [Fact]
+    public async Task TaskToErrorOrAsync_WhenAccessingValue_ShouldReturnValue()
+    {
+        // Arrange
+        int value = 5;
+        Task<int> task = Task.FromResult(value);
+
+        // Act
+        ErrorOr<int> result = await task.ToErrorOrAsync();
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.Should().Be(value);
+    }
+
+    [Fact]
     public void ErrorToErrorOr_WhenAccessingFirstError_ShouldReturnSameError()
     {
         // Arrange


### PR DESCRIPTION
In my current project, we are using a `ToErrorOrAsync` extension method to create `ErrorOr`-objects from async calls. We mainly use this to add conditions to database calls, allowing us to concisely check the returned value and define errors for non-matching return values.

Example:
```c#
public async Task<ErrorOr<User>> GetAdminUser(Guid userId)
{
    return await userRepository.FindById(id)
        .ToErrorOrAsync()
        .FailIf(x => x is null, UserErrors.NotFound(id))
        .Then(x => x!)
        .FailIf(x => !x.IsAdmin, UserErrors.InsufficientPermissions(id))
        .FailIf(x => x.IsDeactivated, UserErrors.Deactivated(id));
}
```

This can be solved by awaiting the call first, either by storing it in a variable (`User? user = await userRepository.FindById(id); return user.ToErrorOr()...`) or wrapping the call in brackets (`return (await ...).ToErrorOr()...`), but - at least for us - this extension method is preferred. The method works well with the existing `Task<ErrorOr<T>>`-overloads that have recently been added for the other methods (`FailIf`, `Then`, ...).

If you think this might be a good addition for this library, I'd be happy to get this merged and add changes if necessary.