### PR TITLE
CHANGELOG supplementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,67 +2,13 @@
 
 All notable changes to this project are documented in this file.
 
-## [1.10.0] - 2024-02-14
-
-### Added
-
-- `ErrorType.Forbidden`
-- README to NuGet package
-
-## [1.9.0] - 2024-01-06
-
-### Added
-
-- `ToErrorOr`
-
-## [2.0.1] - 2024-03-26
-
-### Added
-
-- `FailIf`
-
-    ```csharp
-    public ErrorOr<TValue> FailIf(Func<TValue, bool> onValue, Error error)
-    ```
-
-    ```csharp
-    ErrorOr<int> errorOr = 1;
-    errorOr.FailIf(x => x > 0, Error.Failure());
-    ```
-
-### Breaking Changes
-
-- `Then` that receives an action is now called `ThenDo`
-
-    ```diff
-    -public ErrorOr<TValue> Then(Action<TValue> action)
-    +public ErrorOr<TValue> ThenDo(Action<TValue> action)
-    ```
-
-    ```diff
-    -public static async Task<ErrorOr<TValue>> Then<TValue>(this Task<ErrorOr<TValue>> errorOr, Action<TValue> action)
-    +public static async Task<ErrorOr<TValue>> ThenDo<TValue>(this Task<ErrorOr<TValue>> errorOr, Action<TValue> action)
-    ```
-
-- `ThenAsync` that receives an action is now called `ThenDoAsync`
-
-    ```diff
-    -public async Task<ErrorOr<TValue>> ThenAsync(Func<TValue, Task> action)
-    +public async Task<ErrorOr<TValue>> ThenDoAsync(Func<TValue, Task> action)
-    ```
-
-    ```diff
-    -public static async Task<ErrorOr<TValue>> ThenAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task> action)
-    +public static async Task<ErrorOr<TValue>> ThenDoAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task> action)
-    ```
-
 ## [3.0.0-alpha.0] - to be released
 
 ### Breaking Changes
 
-- (#104) Support for .NET 6 was removed
+- [#104](https://github.com/amantinband/error-or/pull/104) Support for .NET 6 was removed
 
-- (#105) Invalid use of library now throws exception instead of return errors
+- [#105](https://github.com/amantinband/error-or/pull/105) Invalid use of library now throws exception instead of return errors
 
     Following actions now throws `InvalidOperationException`:
 
@@ -72,7 +18,7 @@ All notable changes to this project are documented in this file.
 
 ### Added
 
-- (#94, #95) Added missing async versions of `FailIf` methods (thanks [@MGREMY](https://github.com/MGREMY)!)
+- [#94](https://github.com/amantinband/error-or/issues/94), [#95](https://github.com/amantinband/error-or/pull/95) Added missing async versions of `FailIf` methods (thanks [@MGREMY](https://github.com/MGREMY)!)
 
     ```cs
     public async Task<ErrorOr<TValue>> FailIfAsync(Func<TValue, Task<bool>> onValue, Error error)
@@ -92,9 +38,9 @@ All notable changes to this project are documented in this file.
         Error error)
     ```
 
-- (#104) Support for .NET 8 was added
+- [#104](https://github.com/amantinband/error-or/pull/104) Support for .NET 8 was added
 
-- (#109, #111) Added `FailIf` method overloads that allow to use value in error definition using `Func<TValue, Error>` error builder (thanks [@ahmtsen](https://github.com/ahmtsen)!)
+- [#109](https://github.com/amantinband/error-or/issues/109), [#111](https://github.com/amantinband/error-or/pull/111) Added `FailIf` method overloads that allow to use value in error definition using `Func<TValue, Error>` error builder (thanks [@ahmtsen](https://github.com/ahmtsen)!)
 
     ```cs
     public ErrorOr<TValue> FailIf(Func<TValue, bool> onValue, Func<TValue, Error> errorBuilder)
@@ -127,10 +73,64 @@ All notable changes to this project are documented in this file.
 
 ### Fixed
 
-- (#85, #97) `ErrorOr` turned into Value Object by reimplementing `Equals` and `GetHashCode` methods
+- [#85](https://github.com/amantinband/error-or/issues/85), [#97](https://github.com/amantinband/error-or/pull/97) `ErrorOr` turned into Value Object by reimplementing `Equals` and `GetHashCode` methods
 
     New dependency was introduced to [Microsoft.Bcl.HashCode](https://www.nuget.org/packages/Microsoft.Bcl.HashCode) and development dependency was introduced to [Nullable](https://www.nuget.org/packages/Nullable)
 
 ### Optimized
 
-- (#98, #99) Memory consumption optimized by moving static empty errors lists from generic struct into non-generic class
+- [#98](https://github.com/amantinband/error-or/issues/98), [#99](https://github.com/amantinband/error-or/pull/99) Memory consumption optimized by moving static empty errors lists from generic struct into non-generic class
+
+## [2.0.1] - 2024-03-26
+
+### Breaking Changes
+
+- `Then` that receives an action is now called `ThenDo`
+
+    ```diff
+    -public ErrorOr<TValue> Then(Action<TValue> action)
+    +public ErrorOr<TValue> ThenDo(Action<TValue> action)
+    ```
+
+    ```diff
+    -public static async Task<ErrorOr<TValue>> Then<TValue>(this Task<ErrorOr<TValue>> errorOr, Action<TValue> action)
+    +public static async Task<ErrorOr<TValue>> ThenDo<TValue>(this Task<ErrorOr<TValue>> errorOr, Action<TValue> action)
+    ```
+
+- `ThenAsync` that receives an action is now called `ThenDoAsync`
+
+    ```diff
+    -public async Task<ErrorOr<TValue>> ThenAsync(Func<TValue, Task> action)
+    +public async Task<ErrorOr<TValue>> ThenDoAsync(Func<TValue, Task> action)
+    ```
+
+    ```diff
+    -public static async Task<ErrorOr<TValue>> ThenAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task> action)
+    +public static async Task<ErrorOr<TValue>> ThenDoAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task> action)
+    ```
+
+### Added
+
+- `FailIf`
+
+    ```csharp
+    public ErrorOr<TValue> FailIf(Func<TValue, bool> onValue, Error error)
+    ```
+
+    ```csharp
+    ErrorOr<int> errorOr = 1;
+    errorOr.FailIf(x => x > 0, Error.Failure());
+    ```
+
+## [1.10.0] - 2024-02-14
+
+### Added
+
+- `ErrorType.Forbidden`
+- README to NuGet package
+
+## [1.9.0] - 2024-01-06
+
+### Added
+
+- `ToErrorOr`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,3 +110,9 @@ Value can now be used to build the error:
 ErrorOr<int> result = errorOrInt
     .FailIf(num => num > 3, (num) => Error.Failure(description: $"{num} is greater than 3"));
 ```
+
+### Fixed
+
+- (#85, #97) `ErrorOr` turned into Value Object by reimplementing `Equals` and `GetHashCode` methods
+
+New dependency was introduced to [Microsoft.Bcl.HashCode](https://www.nuget.org/packages/Microsoft.Bcl.HashCode) and development dependency was introduced to [Nullable](https://www.nuget.org/packages/Nullable)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ errorOr.FailIf(x => x > 0, Error.Failure());
 
 ## [3.0.0-alpha.0] - to be released
 
+### Breaking Changes
+
+- (#104) Support for .NET 6 was removed
+
 ### Added
 
 - (#94, #95) Added missing async versions of `FailIf` methods (thanks [@MGREMY](https://github.com/MGREMY)!)
@@ -79,6 +83,8 @@ public static async Task<ErrorOr<TValue>> FailIfAsync<TValue>(
     Func<TValue, Task<bool>> onValue,
     Error error)
 ```
+
+- (#104) Support for .NET 8 was added
 
 - (#109, #111) Added `FailIf` method overloads that allow to use value in error definition using `Func<TValue, Error>` error builder (thanks [@ahmtsen](https://github.com/ahmtsen)!)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,40 +21,40 @@ All notable changes to this project are documented in this file.
 
 - `FailIf`
 
-```csharp
-public ErrorOr<TValue> FailIf(Func<TValue, bool> onValue, Error error)
-```
+    ```csharp
+    public ErrorOr<TValue> FailIf(Func<TValue, bool> onValue, Error error)
+    ```
 
-```csharp
-ErrorOr<int> errorOr = 1;
-errorOr.FailIf(x => x > 0, Error.Failure());
-```
+    ```csharp
+    ErrorOr<int> errorOr = 1;
+    errorOr.FailIf(x => x > 0, Error.Failure());
+    ```
 
 ### Breaking Changes
 
 - `Then` that receives an action is now called `ThenDo`
 
-```diff
--public ErrorOr<TValue> Then(Action<TValue> action)
-+public ErrorOr<TValue> ThenDo(Action<TValue> action)
-```
+    ```diff
+    -public ErrorOr<TValue> Then(Action<TValue> action)
+    +public ErrorOr<TValue> ThenDo(Action<TValue> action)
+    ```
 
-```diff
--public static async Task<ErrorOr<TValue>> Then<TValue>(this Task<ErrorOr<TValue>> errorOr, Action<TValue> action)
-+public static async Task<ErrorOr<TValue>> ThenDo<TValue>(this Task<ErrorOr<TValue>> errorOr, Action<TValue> action)
-```
+    ```diff
+    -public static async Task<ErrorOr<TValue>> Then<TValue>(this Task<ErrorOr<TValue>> errorOr, Action<TValue> action)
+    +public static async Task<ErrorOr<TValue>> ThenDo<TValue>(this Task<ErrorOr<TValue>> errorOr, Action<TValue> action)
+    ```
 
 - `ThenAsync` that receives an action is now called `ThenDoAsync`
 
-```diff
--public async Task<ErrorOr<TValue>> ThenAsync(Func<TValue, Task> action)
-+public async Task<ErrorOr<TValue>> ThenDoAsync(Func<TValue, Task> action)
-```
+    ```diff
+    -public async Task<ErrorOr<TValue>> ThenAsync(Func<TValue, Task> action)
+    +public async Task<ErrorOr<TValue>> ThenDoAsync(Func<TValue, Task> action)
+    ```
 
-```diff
--public static async Task<ErrorOr<TValue>> ThenAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task> action)
-+public static async Task<ErrorOr<TValue>> ThenDoAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task> action)
-```
+    ```diff
+    -public static async Task<ErrorOr<TValue>> ThenAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task> action)
+    +public static async Task<ErrorOr<TValue>> ThenDoAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task> action)
+    ```
 
 ## [3.0.0-alpha.0] - to be released
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,3 +55,58 @@ errorOr.FailIf(x => x > 0, Error.Failure());
 -public static async Task<ErrorOr<TValue>> ThenAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task> action)
 +public static async Task<ErrorOr<TValue>> ThenDoAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task> action)
 ```
+
+## [3.0.0-alpha.0] - to be released
+
+### Added
+
+- (#94, #95) Added missing async versions of `FailIf` methods (thanks [@MGREMY](https://github.com/MGREMY)!)
+
+```cs
+public async Task<ErrorOr<TValue>> FailIfAsync(Func<TValue, Task<bool>> onValue, Error error)
+```
+
+```cs
+public static async Task<ErrorOr<TValue>> FailIf<TValue>(
+    this Task<ErrorOr<TValue>> errorOr,
+    Func<TValue, bool> onValue,
+    Error error)
+```
+
+```cs
+public static async Task<ErrorOr<TValue>> FailIfAsync<TValue>(
+    this Task<ErrorOr<TValue>> errorOr,
+    Func<TValue, Task<bool>> onValue,
+    Error error)
+```
+
+- (#109, #111) Added `FailIf` method overloads that allow to use value in error definition using `Func<TValue, Error>` error builder (thanks [@ahmtsen](https://github.com/ahmtsen)!)
+
+```cs
+public ErrorOr<TValue> FailIf(Func<TValue, bool> onValue, Func<TValue, Error> errorBuilder)
+```
+
+```cs
+public async Task<ErrorOr<TValue>> FailIfAsync(Func<TValue, Task<bool>> onValue, Func<TValue, Task<Error>> errorBuilder)
+```
+
+```cs
+public static async Task<ErrorOr<TValue>> FailIf<TValue>(
+    this Task<ErrorOr<TValue>> errorOr,
+    Func<TValue, bool> onValue,
+    Func<TValue, Error> errorBuilder)
+```
+
+```cs
+public static async Task<ErrorOr<TValue>> FailIfAsync<TValue>(
+    this Task<ErrorOr<TValue>> errorOr,
+    Func<TValue, Task<bool>> onValue,
+    Func<TValue, Task<Error>> errorBuilder)
+```
+
+Value can now be used to build the error:
+
+```cs
+ErrorOr<int> result = errorOrInt
+    .FailIf(num => num > 3, (num) => Error.Failure(description: $"{num} is greater than 3"));
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,62 +74,62 @@ errorOr.FailIf(x => x > 0, Error.Failure());
 
 - (#94, #95) Added missing async versions of `FailIf` methods (thanks [@MGREMY](https://github.com/MGREMY)!)
 
-```cs
-public async Task<ErrorOr<TValue>> FailIfAsync(Func<TValue, Task<bool>> onValue, Error error)
-```
+    ```cs
+    public async Task<ErrorOr<TValue>> FailIfAsync(Func<TValue, Task<bool>> onValue, Error error)
+    ```
 
-```cs
-public static async Task<ErrorOr<TValue>> FailIf<TValue>(
-    this Task<ErrorOr<TValue>> errorOr,
-    Func<TValue, bool> onValue,
-    Error error)
-```
+    ```cs
+    public static async Task<ErrorOr<TValue>> FailIf<TValue>(
+        this Task<ErrorOr<TValue>> errorOr,
+        Func<TValue, bool> onValue,
+        Error error)
+    ```
 
-```cs
-public static async Task<ErrorOr<TValue>> FailIfAsync<TValue>(
-    this Task<ErrorOr<TValue>> errorOr,
-    Func<TValue, Task<bool>> onValue,
-    Error error)
-```
+    ```cs
+    public static async Task<ErrorOr<TValue>> FailIfAsync<TValue>(
+        this Task<ErrorOr<TValue>> errorOr,
+        Func<TValue, Task<bool>> onValue,
+        Error error)
+    ```
 
 - (#104) Support for .NET 8 was added
 
 - (#109, #111) Added `FailIf` method overloads that allow to use value in error definition using `Func<TValue, Error>` error builder (thanks [@ahmtsen](https://github.com/ahmtsen)!)
 
-```cs
-public ErrorOr<TValue> FailIf(Func<TValue, bool> onValue, Func<TValue, Error> errorBuilder)
-```
+    ```cs
+    public ErrorOr<TValue> FailIf(Func<TValue, bool> onValue, Func<TValue, Error> errorBuilder)
+    ```
 
-```cs
-public async Task<ErrorOr<TValue>> FailIfAsync(Func<TValue, Task<bool>> onValue, Func<TValue, Task<Error>> errorBuilder)
-```
+    ```cs
+    public async Task<ErrorOr<TValue>> FailIfAsync(Func<TValue, Task<bool>> onValue, Func<TValue, Task<Error>> errorBuilder)
+    ```
 
-```cs
-public static async Task<ErrorOr<TValue>> FailIf<TValue>(
-    this Task<ErrorOr<TValue>> errorOr,
-    Func<TValue, bool> onValue,
-    Func<TValue, Error> errorBuilder)
-```
+    ```cs
+    public static async Task<ErrorOr<TValue>> FailIf<TValue>(
+        this Task<ErrorOr<TValue>> errorOr,
+        Func<TValue, bool> onValue,
+        Func<TValue, Error> errorBuilder)
+    ```
 
-```cs
-public static async Task<ErrorOr<TValue>> FailIfAsync<TValue>(
-    this Task<ErrorOr<TValue>> errorOr,
-    Func<TValue, Task<bool>> onValue,
-    Func<TValue, Task<Error>> errorBuilder)
-```
+    ```cs
+    public static async Task<ErrorOr<TValue>> FailIfAsync<TValue>(
+        this Task<ErrorOr<TValue>> errorOr,
+        Func<TValue, Task<bool>> onValue,
+        Func<TValue, Task<Error>> errorBuilder)
+    ```
 
-Value can now be used to build the error:
+    Value can now be used to build the error:
 
-```cs
-ErrorOr<int> result = errorOrInt
-    .FailIf(num => num > 3, (num) => Error.Failure(description: $"{num} is greater than 3"));
-```
+    ```cs
+    ErrorOr<int> result = errorOrInt
+        .FailIf(num => num > 3, (num) => Error.Failure(description: $"{num} is greater than 3"));
+    ```
 
 ### Fixed
 
 - (#85, #97) `ErrorOr` turned into Value Object by reimplementing `Equals` and `GetHashCode` methods
 
-New dependency was introduced to [Microsoft.Bcl.HashCode](https://www.nuget.org/packages/Microsoft.Bcl.HashCode) and development dependency was introduced to [Nullable](https://www.nuget.org/packages/Nullable)
+    New dependency was introduced to [Microsoft.Bcl.HashCode](https://www.nuget.org/packages/Microsoft.Bcl.HashCode) and development dependency was introduced to [Nullable](https://www.nuget.org/packages/Nullable)
 
 ### Optimized
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,14 @@ errorOr.FailIf(x => x > 0, Error.Failure());
 
 - (#104) Support for .NET 6 was removed
 
+- (#105) Invalid use of library now throws exception instead of return errors
+
+    Following actions now throws `InvalidOperationException`:
+
+    1. Default `ErrorOr` constructor invocation.
+    2. Accessing `ErrorOr.Errors` and `ErrorOr.FirstError` on success result.
+    3. Accessing `ErrorOr.Value` on result with errors.
+
 ### Added
 
 - (#94, #95) Added missing async versions of `FailIf` methods (thanks [@MGREMY](https://github.com/MGREMY)!)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,3 +122,7 @@ ErrorOr<int> result = errorOrInt
 - (#85, #97) `ErrorOr` turned into Value Object by reimplementing `Equals` and `GetHashCode` methods
 
 New dependency was introduced to [Microsoft.Bcl.HashCode](https://www.nuget.org/packages/Microsoft.Bcl.HashCode) and development dependency was introduced to [Nullable](https://www.nuget.org/packages/Nullable)
+
+### Optimized
+
+- (#98, #99) Memory consumption optimized by moving static empty errors lists from generic struct into non-generic class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project are documented in this file.
 
 ### Added
 
-- [#94](https://github.com/amantinband/error-or/issues/94), [#95](https://github.com/amantinband/error-or/pull/95) Added missing async versions of `FailIf` methods (thanks [@MGREMY](https://github.com/MGREMY)!)
+- [#94](https://github.com/amantinband/error-or/issues/94), [#95](https://github.com/amantinband/error-or/pull/95) Added missing async versions of `FailIf` methods
 
     ```cs
     public async Task<ErrorOr<TValue>> FailIfAsync(Func<TValue, Task<bool>> onValue, Error error)
@@ -40,7 +40,7 @@ All notable changes to this project are documented in this file.
 
 - [#104](https://github.com/amantinband/error-or/pull/104) Support for .NET 8 was added
 
-- [#109](https://github.com/amantinband/error-or/issues/109), [#111](https://github.com/amantinband/error-or/pull/111) Added `FailIf` method overloads that allow to use value in error definition using `Func<TValue, Error>` error builder (thanks [@ahmtsen](https://github.com/ahmtsen)!)
+- [#109](https://github.com/amantinband/error-or/issues/109), [#111](https://github.com/amantinband/error-or/pull/111) Added `FailIf` method overloads that allow to use value in error definition using `Func<TValue, Error>` error builder
 
     ```cs
     public ErrorOr<TValue> FailIf(Func<TValue, bool> onValue, Func<TValue, Error> errorBuilder)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project are documented in this file.
 
 - `ToErrorOr`
 
-## [2.0.0] - 2024-03-26
+## [2.0.1] - 2024-03-26
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,21 @@ All notable changes to this project are documented in this file.
         .FailIf(num => num > 3, (num) => Error.Failure(description: $"{num} is greater than 3"));
     ```
 
+- [#117](https://github.com/amantinband/error-or/pull/117) Added `ElseDo` and `ElseDoAsync` methods
+
+    Actions returning no result can now be called when `IsError` is true.
+
+    ```cs
+    ErrorOr<string> foo = result
+        .Else(errors => Error.Unexpected())
+        .ElseDo(error => Console.WriteLine(error.FirstError.Description));
+    ```
+
+    ```cs
+    ErrorOr<string> foo = await result
+        .ElseDoAsync(HandleErrorAsync);
+    ```
+
 ### Fixed
 
 - [#85](https://github.com/amantinband/error-or/issues/85), [#97](https://github.com/amantinband/error-or/pull/97) `ErrorOr` turned into Value Object by reimplementing `Equals` and `GetHashCode` methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,8 @@ All notable changes to this project are documented in this file.
     ErrorOr<int> errorOrPerson = ErrorOr<int>.From([Error.Validation(), Error.Validation()]);
     ```
 
+- [#149](https://github.com/amantinband/error-or/pull/149) Added `Else`/`ElseAsync` overloads returning `ErrorOr`
+
 ### Fixed
 
 - [#85](https://github.com/amantinband/error-or/issues/85), [#97](https://github.com/amantinband/error-or/pull/97) `ErrorOr` turned into Value Object by reimplementing `Equals` and `GetHashCode` methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,10 @@ All notable changes to this project are documented in this file.
 
     New dependency was introduced to [Microsoft.Bcl.HashCode](https://www.nuget.org/packages/Microsoft.Bcl.HashCode) and development dependency was introduced to [Nullable](https://www.nuget.org/packages/Nullable)
 
+- [#150](https://github.com/amantinband/error-or/pull/150) `EmptyErrors.Instance` returns new `List<Error>` instance on each call
+
+    This allows to avoid mutating empty list
+
 ### Optimized
 
 - [#98](https://github.com/amantinband/error-or/issues/98), [#99](https://github.com/amantinband/error-or/pull/99) Memory consumption optimized by moving static empty errors lists from generic struct into non-generic class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,14 @@ All notable changes to this project are documented in this file.
         .ElseDoAsync(HandleErrorAsync);
     ```
 
+- [#122](https://github.com/amantinband/error-or/pull/122) Added `ToErrorOrAsync` method
+
+    Values in `Task` can now be easily converted to `ErrorOr`.
+
+    ```cs
+    ErrorOr<int> result = await Task.FromResult(5).ToErrorOrAsync();
+    ```
+
 ### Fixed
 
 - [#85](https://github.com/amantinband/error-or/issues/85), [#97](https://github.com/amantinband/error-or/pull/97) `ErrorOr` turned into Value Object by reimplementing `Equals` and `GetHashCode` methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,21 @@ All notable changes to this project are documented in this file.
     ErrorOr<int> result = await Task.FromResult(5).ToErrorOrAsync();
     ```
 
+- [#129](https://github.com/amantinband/error-or/pull/129) Added missing `ErrorOrFactory.From` methods
+
+    Now following calls from `README.md` are available
+
+    ```cs
+    ErrorOr<int> result = ErrorOrFactory.From<int>(Error.Unexpected());
+    ErrorOr<int> result = ErrorOrFactory.From<int>([Error.Validation(), Error.Validation()]);
+    ```
+
+    Following call is now obsolete
+
+    ```cs
+    ErrorOr<int> errorOrPerson = ErrorOr<int>.From([Error.Validation(), Error.Validation()]);
+    ```
+
 ### Fixed
 
 - [#85](https://github.com/amantinband/error-or/issues/85), [#97](https://github.com/amantinband/error-or/pull/97) `ErrorOr` turned into Value Object by reimplementing `Equals` and `GetHashCode` methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,10 @@ All notable changes to this project are documented in this file.
 
 - [#98](https://github.com/amantinband/error-or/issues/98), [#99](https://github.com/amantinband/error-or/pull/99) Memory consumption optimized by moving static empty errors lists from generic struct into non-generic class
 
+### Refactored
+
+- [#154](https://github.com/amantinband/error-or/pull/154) Modernized NuGet publish workflow
+
 ## [2.0.1] - 2024-03-26
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,14 @@ All notable changes to this project are documented in this file.
     ErrorOr<int> errorOrPerson = ErrorOr<int>.From([Error.Validation(), Error.Validation()]);
     ```
 
+- [#133](https://github.com/amantinband/error-or/pull/133) Added missing collection expression support
+
+    Now following call from `README.md` is available
+
+    ```cs
+    ErrorOr<int> result = [Error.Validation(), Error.Validation()];
+    ```
+
 - [#149](https://github.com/amantinband/error-or/pull/149) Added `Else`/`ElseAsync` overloads returning `ErrorOr`
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented in this file.
 
-## [3.0.0-alpha.0] - to be released
+## [3.0.0] - to be released
 
 ### Breaking Changes
 
@@ -11,7 +11,6 @@ All notable changes to this project are documented in this file.
 - [#105](https://github.com/amantinband/error-or/pull/105) Invalid use of library now throws exception instead of return errors
 
     Following actions now throws `InvalidOperationException`:
-
     1. Default `ErrorOr` constructor invocation.
     2. Accessing `ErrorOr.Errors` and `ErrorOr.FirstError` on success result.
     3. Accessing `ErrorOr.Value` on result with errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,8 @@ All notable changes to this project are documented in this file.
 
 - [#98](https://github.com/amantinband/error-or/issues/98), [#99](https://github.com/amantinband/error-or/pull/99) Memory consumption optimized by moving static empty errors lists from generic struct into non-generic class
 
+- [#128](https://github.com/error-or/error-or/pull/128) Removed unneccessary null check from `ErrorOr(List<Error>)` constructor
+
 ### Refactored
 
 - [#154](https://github.com/amantinband/error-or/pull/154) Modernized NuGet publish workflow


### PR DESCRIPTION
In order to facilitate more dynamic releases I have described changes made since 2.0.1 release. Please take a look before merging further PR's. I have reordered CHANGELOG entries so that descending order of versions is now applied. Please also note that these changelog contains breaking changes. Without reverting 3.0.0 release is prefered.