### PR TITLE
Update ErrorOr.cs | removal of the second null check for errors | pri…

### DIFF
--- a/src/ErrorOr/ErrorOr.cs
+++ b/src/ErrorOr/ErrorOr.cs
@@ -32,7 +32,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
             throw new ArgumentNullException(nameof(errors));
         }
 
-        if (errors is null || errors.Count == 0)
+        if (errors.Count == 0)
         {
             throw new ArgumentException("Cannot create an ErrorOr<TValue> from an empty collection of errors. Provide at least one error.", nameof(errors));
         }


### PR DESCRIPTION
…vate ErrorOr(List<Error> errors)

private ErrorOr(List<Error> errors)
{
	if (errors is null)
	{
		throw new ArgumentNullException(nameof(errors));
	}

	if (errors is null || errors.Count == 0)
	{
		throw new ArgumentException("Cannot create an ErrorOr<TValue> from an empty collection of errors. Provide at least one error.", nameof(errors));
	}

	_errors = errors;
}

This check is unnecessary due to the one performed just above.