### PR TITLE
Bugfix: added from errors factory methods

### DIFF
--- a/src/ErrorOr/ErrorOr.cs
+++ b/src/ErrorOr/ErrorOr.cs
@@ -107,6 +107,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> from a list of errors.
     /// </summary>
+    [Obsolete("ErrorOrFactory.From<TValue>(errors) should be used instead.")]
     public static ErrorOr<TValue> From(List<Error> errors)
     {
         return errors;

--- a/src/ErrorOr/ErrorOrFactory.cs
+++ b/src/ErrorOr/ErrorOrFactory.cs
@@ -15,4 +15,15 @@ public static class ErrorOrFactory
     {
         return value;
     }
+
+    /// <summary>
+    /// Creates an <see cref="ErrorOr{TValue}"/> from a list of errors.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <param name="errors">List of errors.</param>
+    /// <returns>An instance of <see cref="ErrorOr{TValue}"/> containing provided list of errors.</returns>
+    public static ErrorOr<TValue> From<TValue>(List<Error> errors)
+    {
+        return errors;
+    }
 }

--- a/src/ErrorOr/ErrorOrFactory.cs
+++ b/src/ErrorOr/ErrorOrFactory.cs
@@ -17,6 +17,17 @@ public static class ErrorOrFactory
     }
 
     /// <summary>
+    /// Creates a new instance of <see cref="ErrorOr{TValue}"/> from single error.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <param name="error">Single error instance to wrap.</param>
+    /// <returns>An instance of <see cref="ErrorOr{TValue}"/> containing the provided error.</returns>
+    public static ErrorOr<TValue> From<TValue>(Error error)
+    {
+        return error;
+    }
+
+    /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> from a list of errors.
     /// </summary>
     /// <typeparam name="TValue">The type of the value.</typeparam>

--- a/src/ErrorOr/ErrorOrFactory.cs
+++ b/src/ErrorOr/ErrorOrFactory.cs
@@ -26,4 +26,15 @@ public static class ErrorOrFactory
     {
         return errors;
     }
+
+    /// <summary>
+    /// Creates an <see cref="ErrorOr{TValue}"/> from an enumeration of errors.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <param name="errors">Enumeration of errors.</param>
+    /// <returns>An instance of <see cref="ErrorOr{TValue}"/> containing provided enumeration of errors.</returns>
+    public static ErrorOr<TValue> From<TValue>(IEnumerable<Error> errors)
+    {
+        return errors.ToList();
+    }
 }

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -1,6 +1,7 @@
 namespace Tests;
 
 using ErrorOr;
+
 using FluentAssertions;
 
 public class ErrorOrInstantiationTests
@@ -145,6 +146,22 @@ public class ErrorOrInstantiationTests
         // Assert
         act.Should().Throw<InvalidOperationException>()
            .And.Message.Should().Be("The Value property cannot be accessed when errors have been recorded. Check IsError before accessing Value.");
+    }
+
+    [Fact]
+    public void CreateFromArrayOfErrors_UsingFactory_ShouldBeError()
+    {
+        // Arrange
+        Error[] errors = [
+            Error.Validation("User.Name", "Name is too short"),
+            Error.Forbidden("User.Forbidden", "You are not allowed to create user")
+        ];
+
+        // Act
+        ErrorOr<Person> errorOrPerson = ErrorOrFactory.From<Person>(errors);
+
+        // Assert
+        errorOrPerson.IsError.Should().BeTrue();
     }
 
     [Fact]

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -64,6 +64,20 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
+    public void CreateFromErrorList_UsingFactory_WhenAccessingErrors_ShouldReturnErrorList()
+    {
+        // Arrange
+        var error = Error.Validation("User.Name", "Name is too short");
+
+        // Act
+        ErrorOr<Person> errorOrPerson = ErrorOrFactory.From<Person>([error]);
+
+        // Assert
+        errorOrPerson.IsError.Should().BeTrue();
+        errorOrPerson.Errors.Should().ContainSingle().Which.Should().Be(error);
+    }
+
+    [Fact]
     public void CreateFromErrorList_WhenAccessingErrors_ShouldReturnErrorList()
     {
         // Arrange
@@ -76,6 +90,20 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
+    public void CreateFromErrorList_UsingFactory_WhenAccessingErrorsOrEmptyList_ShouldReturnErrorList()
+    {
+        // Arrange
+        var error = Error.Validation("User.Name", "Name is too short");
+
+        // Act
+        ErrorOr<Person> errorOrPerson = ErrorOrFactory.From<Person>([error]);
+
+        // Assert
+        errorOrPerson.IsError.Should().BeTrue();
+        errorOrPerson.ErrorsOrEmptyList.Should().ContainSingle().Which.Should().Be(error);
+    }
+
+    [Fact]
     public void CreateFromErrorList_WhenAccessingErrorsOrEmptyList_ShouldReturnErrorList()
     {
         // Arrange
@@ -85,6 +113,20 @@ public class ErrorOrInstantiationTests
         // Act & Assert
         errorOrPerson.IsError.Should().BeTrue();
         errorOrPerson.ErrorsOrEmptyList.Should().ContainSingle().Which.Should().Be(errors.Single());
+    }
+
+    [Fact]
+    public void CreateFromErrorList_UsingFactory_WhenAccessingValue_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        ErrorOr<Person> errorOrPerson = ErrorOrFactory.From<Person>([Error.Validation("User.Name", "Name is too short")]);
+
+        // Act
+        var act = () => errorOrPerson.Value;
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+           .And.Message.Should().Be("The Value property cannot be accessed when errors have been recorded. Check IsError before accessing Value.");
     }
 
     [Fact]

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -78,6 +78,7 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
+    [Obsolete]
     public void CreateFromErrorList_WhenAccessingErrors_ShouldReturnErrorList()
     {
         // Arrange
@@ -104,6 +105,7 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
+    [Obsolete]
     public void CreateFromErrorList_WhenAccessingErrorsOrEmptyList_ShouldReturnErrorList()
     {
         // Arrange
@@ -130,6 +132,7 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
+    [Obsolete]
     public void CreateFromErrorList_WhenAccessingValue_ShouldThrowInvalidOperationException()
     {
         // Arrange

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -149,6 +149,16 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
+    public void CreateFromSingleError_UsingFactory_ShouldBeError()
+    {
+        // Act
+        ErrorOr<Person> errorOrPerson = ErrorOrFactory.From<Person>(Error.Validation("User.Name", "Name is too short"));
+
+        // Assert
+        errorOrPerson.IsError.Should().BeTrue();
+    }
+
+    [Fact]
     public void CreateFromArrayOfErrors_UsingFactory_ShouldBeError()
     {
         // Arrange

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -8,62 +8,6 @@ public class ErrorOrInstantiationTests
     private record Person(string Name);
 
     [Fact]
-    public void CreateFromFactory_WhenAccessingValue_ShouldReturnValue()
-    {
-        // Arrange
-        IEnumerable<string> value = ["value"];
-
-        // Act
-        ErrorOr<IEnumerable<string>> errorOrPerson = ErrorOrFactory.From(value);
-
-        // Assert
-        errorOrPerson.IsError.Should().BeFalse();
-        errorOrPerson.Value.Should().BeSameAs(value);
-    }
-
-    [Fact]
-    public void CreateFromFactory_WhenAccessingErrors_ShouldThrow()
-    {
-        // Arrange
-        IEnumerable<string> value = ["value"];
-        ErrorOr<IEnumerable<string>> errorOrPerson = ErrorOrFactory.From(value);
-
-        // Act
-        Func<List<Error>> errors = () => errorOrPerson.Errors;
-
-        // Assert
-        errors.Should().ThrowExactly<InvalidOperationException>();
-    }
-
-    [Fact]
-    public void CreateFromFactory_WhenAccessingErrorsOrEmptyList_ShouldReturnEmptyList()
-    {
-        // Arrange
-        IEnumerable<string> value = ["value"];
-        ErrorOr<IEnumerable<string>> errorOrPerson = ErrorOrFactory.From(value);
-
-        // Act
-        List<Error> errors = errorOrPerson.ErrorsOrEmptyList;
-
-        // Assert
-        errors.Should().BeEmpty();
-    }
-
-    [Fact]
-    public void CreateFromFactory_WhenAccessingFirstError_ShouldThrow()
-    {
-        // Arrange
-        IEnumerable<string> value = ["value"];
-        ErrorOr<IEnumerable<string>> errorOrPerson = ErrorOrFactory.From(value);
-
-        // Act
-        Func<Error> action = () => errorOrPerson.FirstError;
-
-        // Assert
-        action.Should().ThrowExactly<InvalidOperationException>();
-    }
-
-    [Fact]
     public void CreateFromValue_WhenAccessingValue_ShouldReturnValue()
     {
         // Arrange


### PR DESCRIPTION
In [README.md](https://github.com/amantinband/error-or?tab=readme-ov-file#using-the-errororfactory) there are examples of creating `ErrorOr` form single error as well as list of errors using `ErrorOrFactory.From<int>(errors)` but in library no such method exist. Here are implementations of those methods. Additionally `ErrorOr<TValue>.From(errors)` method is being marked as obsolete.

Examples:
```cs
ErrorOr<int> result = ErrorOrFactory.From<int>(Error.Unexpected());
ErrorOr<int> result = ErrorOrFactory.From<int>([Error.Validation(), Error.Validation()]);
```
```cs
public ErrorOr<int> MultipleErrorsToErrorOr()
{
    return ErrorOrFactory.From([
        Error.Validation(description: "Invalid Name"),
        Error.Validation(description: "Invalid Last Name")
    ]);
}
```
```cs
// Now obsolete
ErrorOr<Person> errorOrPerson = ErrorOr<Person>.From([Error.Validation(), Error.Validation()]);
```