### PR TITLE
Revert: breaking changes (compared to 2.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,67 +2,13 @@
 
 All notable changes to this project are documented in this file.
 
-## [1.10.0] - 2024-02-14
-
-### Added
-
-- `ErrorType.Forbidden`
-- README to NuGet package
-
-## [1.9.0] - 2024-01-06
-
-### Added
-
-- `ToErrorOr`
-
-## [2.0.1] - 2024-03-26
-
-### Added
-
-- `FailIf`
-
-    ```csharp
-    public ErrorOr<TValue> FailIf(Func<TValue, bool> onValue, Error error)
-    ```
-
-    ```csharp
-    ErrorOr<int> errorOr = 1;
-    errorOr.FailIf(x => x > 0, Error.Failure());
-    ```
-
-### Breaking Changes
-
-- `Then` that receives an action is now called `ThenDo`
-
-    ```diff
-    -public ErrorOr<TValue> Then(Action<TValue> action)
-    +public ErrorOr<TValue> ThenDo(Action<TValue> action)
-    ```
-
-    ```diff
-    -public static async Task<ErrorOr<TValue>> Then<TValue>(this Task<ErrorOr<TValue>> errorOr, Action<TValue> action)
-    +public static async Task<ErrorOr<TValue>> ThenDo<TValue>(this Task<ErrorOr<TValue>> errorOr, Action<TValue> action)
-    ```
-
-- `ThenAsync` that receives an action is now called `ThenDoAsync`
-
-    ```diff
-    -public async Task<ErrorOr<TValue>> ThenAsync(Func<TValue, Task> action)
-    +public async Task<ErrorOr<TValue>> ThenDoAsync(Func<TValue, Task> action)
-    ```
-
-    ```diff
-    -public static async Task<ErrorOr<TValue>> ThenAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task> action)
-    +public static async Task<ErrorOr<TValue>> ThenDoAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task> action)
-    ```
-
 ## [3.0.0-alpha.0] - to be released
 
 ### Breaking Changes
 
-- (#104) Support for .NET 6 was removed
+- [#104](https://github.com/amantinband/error-or/pull/104) Support for .NET 6 was removed
 
-- (#105) Invalid use of library now throws exception instead of return errors
+- [#105](https://github.com/amantinband/error-or/pull/105) Invalid use of library now throws exception instead of return errors
 
     Following actions now throws `InvalidOperationException`:
 
@@ -72,7 +18,7 @@ All notable changes to this project are documented in this file.
 
 ### Added
 
-- (#94, #95) Added missing async versions of `FailIf` methods (thanks [@MGREMY](https://github.com/MGREMY)!)
+- [#94](https://github.com/amantinband/error-or/issues/94), [#95](https://github.com/amantinband/error-or/pull/95) Added missing async versions of `FailIf` methods (thanks [@MGREMY](https://github.com/MGREMY)!)
 
     ```cs
     public async Task<ErrorOr<TValue>> FailIfAsync(Func<TValue, Task<bool>> onValue, Error error)
@@ -92,9 +38,9 @@ All notable changes to this project are documented in this file.
         Error error)
     ```
 
-- (#104) Support for .NET 8 was added
+- [#104](https://github.com/amantinband/error-or/pull/104) Support for .NET 8 was added
 
-- (#109, #111) Added `FailIf` method overloads that allow to use value in error definition using `Func<TValue, Error>` error builder (thanks [@ahmtsen](https://github.com/ahmtsen)!)
+- [#109](https://github.com/amantinband/error-or/issues/109), [#111](https://github.com/amantinband/error-or/pull/111) Added `FailIf` method overloads that allow to use value in error definition using `Func<TValue, Error>` error builder (thanks [@ahmtsen](https://github.com/ahmtsen)!)
 
     ```cs
     public ErrorOr<TValue> FailIf(Func<TValue, bool> onValue, Func<TValue, Error> errorBuilder)
@@ -127,10 +73,64 @@ All notable changes to this project are documented in this file.
 
 ### Fixed
 
-- (#85, #97) `ErrorOr` turned into Value Object by reimplementing `Equals` and `GetHashCode` methods
+- [#85](https://github.com/amantinband/error-or/issues/85), [#97](https://github.com/amantinband/error-or/pull/97) `ErrorOr` turned into Value Object by reimplementing `Equals` and `GetHashCode` methods
 
     New dependency was introduced to [Microsoft.Bcl.HashCode](https://www.nuget.org/packages/Microsoft.Bcl.HashCode) and development dependency was introduced to [Nullable](https://www.nuget.org/packages/Nullable)
 
 ### Optimized
 
-- (#98, #99) Memory consumption optimized by moving static empty errors lists from generic struct into non-generic class
+- [#98](https://github.com/amantinband/error-or/issues/98), [#99](https://github.com/amantinband/error-or/pull/99) Memory consumption optimized by moving static empty errors lists from generic struct into non-generic class
+
+## [2.0.1] - 2024-03-26
+
+### Breaking Changes
+
+- `Then` that receives an action is now called `ThenDo`
+
+    ```diff
+    -public ErrorOr<TValue> Then(Action<TValue> action)
+    +public ErrorOr<TValue> ThenDo(Action<TValue> action)
+    ```
+
+    ```diff
+    -public static async Task<ErrorOr<TValue>> Then<TValue>(this Task<ErrorOr<TValue>> errorOr, Action<TValue> action)
+    +public static async Task<ErrorOr<TValue>> ThenDo<TValue>(this Task<ErrorOr<TValue>> errorOr, Action<TValue> action)
+    ```
+
+- `ThenAsync` that receives an action is now called `ThenDoAsync`
+
+    ```diff
+    -public async Task<ErrorOr<TValue>> ThenAsync(Func<TValue, Task> action)
+    +public async Task<ErrorOr<TValue>> ThenDoAsync(Func<TValue, Task> action)
+    ```
+
+    ```diff
+    -public static async Task<ErrorOr<TValue>> ThenAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task> action)
+    +public static async Task<ErrorOr<TValue>> ThenDoAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task> action)
+    ```
+
+### Added
+
+- `FailIf`
+
+    ```csharp
+    public ErrorOr<TValue> FailIf(Func<TValue, bool> onValue, Error error)
+    ```
+
+    ```csharp
+    ErrorOr<int> errorOr = 1;
+    errorOr.FailIf(x => x > 0, Error.Failure());
+    ```
+
+## [1.10.0] - 2024-02-14
+
+### Added
+
+- `ErrorType.Forbidden`
+- README to NuGet package
+
+## [1.9.0] - 2024-01-06
+
+### Added
+
+- `ToErrorOr`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,3 +110,9 @@ Value can now be used to build the error:
 ErrorOr<int> result = errorOrInt
     .FailIf(num => num > 3, (num) => Error.Failure(description: $"{num} is greater than 3"));
 ```
+
+### Fixed
+
+- (#85, #97) `ErrorOr` turned into Value Object by reimplementing `Equals` and `GetHashCode` methods
+
+New dependency was introduced to [Microsoft.Bcl.HashCode](https://www.nuget.org/packages/Microsoft.Bcl.HashCode) and development dependency was introduced to [Nullable](https://www.nuget.org/packages/Nullable)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ errorOr.FailIf(x => x > 0, Error.Failure());
 
 ## [3.0.0-alpha.0] - to be released
 
+### Breaking Changes
+
+- (#104) Support for .NET 6 was removed
+
 ### Added
 
 - (#94, #95) Added missing async versions of `FailIf` methods (thanks [@MGREMY](https://github.com/MGREMY)!)
@@ -79,6 +83,8 @@ public static async Task<ErrorOr<TValue>> FailIfAsync<TValue>(
     Func<TValue, Task<bool>> onValue,
     Error error)
 ```
+
+- (#104) Support for .NET 8 was added
 
 - (#109, #111) Added `FailIf` method overloads that allow to use value in error definition using `Func<TValue, Error>` error builder (thanks [@ahmtsen](https://github.com/ahmtsen)!)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,40 +21,40 @@ All notable changes to this project are documented in this file.
 
 - `FailIf`
 
-```csharp
-public ErrorOr<TValue> FailIf(Func<TValue, bool> onValue, Error error)
-```
+    ```csharp
+    public ErrorOr<TValue> FailIf(Func<TValue, bool> onValue, Error error)
+    ```
 
-```csharp
-ErrorOr<int> errorOr = 1;
-errorOr.FailIf(x => x > 0, Error.Failure());
-```
+    ```csharp
+    ErrorOr<int> errorOr = 1;
+    errorOr.FailIf(x => x > 0, Error.Failure());
+    ```
 
 ### Breaking Changes
 
 - `Then` that receives an action is now called `ThenDo`
 
-```diff
--public ErrorOr<TValue> Then(Action<TValue> action)
-+public ErrorOr<TValue> ThenDo(Action<TValue> action)
-```
+    ```diff
+    -public ErrorOr<TValue> Then(Action<TValue> action)
+    +public ErrorOr<TValue> ThenDo(Action<TValue> action)
+    ```
 
-```diff
--public static async Task<ErrorOr<TValue>> Then<TValue>(this Task<ErrorOr<TValue>> errorOr, Action<TValue> action)
-+public static async Task<ErrorOr<TValue>> ThenDo<TValue>(this Task<ErrorOr<TValue>> errorOr, Action<TValue> action)
-```
+    ```diff
+    -public static async Task<ErrorOr<TValue>> Then<TValue>(this Task<ErrorOr<TValue>> errorOr, Action<TValue> action)
+    +public static async Task<ErrorOr<TValue>> ThenDo<TValue>(this Task<ErrorOr<TValue>> errorOr, Action<TValue> action)
+    ```
 
 - `ThenAsync` that receives an action is now called `ThenDoAsync`
 
-```diff
--public async Task<ErrorOr<TValue>> ThenAsync(Func<TValue, Task> action)
-+public async Task<ErrorOr<TValue>> ThenDoAsync(Func<TValue, Task> action)
-```
+    ```diff
+    -public async Task<ErrorOr<TValue>> ThenAsync(Func<TValue, Task> action)
+    +public async Task<ErrorOr<TValue>> ThenDoAsync(Func<TValue, Task> action)
+    ```
 
-```diff
--public static async Task<ErrorOr<TValue>> ThenAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task> action)
-+public static async Task<ErrorOr<TValue>> ThenDoAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task> action)
-```
+    ```diff
+    -public static async Task<ErrorOr<TValue>> ThenAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task> action)
+    +public static async Task<ErrorOr<TValue>> ThenDoAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task> action)
+    ```
 
 ## [3.0.0-alpha.0] - to be released
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,3 +55,58 @@ errorOr.FailIf(x => x > 0, Error.Failure());
 -public static async Task<ErrorOr<TValue>> ThenAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task> action)
 +public static async Task<ErrorOr<TValue>> ThenDoAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task> action)
 ```
+
+## [3.0.0-alpha.0] - to be released
+
+### Added
+
+- (#94, #95) Added missing async versions of `FailIf` methods (thanks [@MGREMY](https://github.com/MGREMY)!)
+
+```cs
+public async Task<ErrorOr<TValue>> FailIfAsync(Func<TValue, Task<bool>> onValue, Error error)
+```
+
+```cs
+public static async Task<ErrorOr<TValue>> FailIf<TValue>(
+    this Task<ErrorOr<TValue>> errorOr,
+    Func<TValue, bool> onValue,
+    Error error)
+```
+
+```cs
+public static async Task<ErrorOr<TValue>> FailIfAsync<TValue>(
+    this Task<ErrorOr<TValue>> errorOr,
+    Func<TValue, Task<bool>> onValue,
+    Error error)
+```
+
+- (#109, #111) Added `FailIf` method overloads that allow to use value in error definition using `Func<TValue, Error>` error builder (thanks [@ahmtsen](https://github.com/ahmtsen)!)
+
+```cs
+public ErrorOr<TValue> FailIf(Func<TValue, bool> onValue, Func<TValue, Error> errorBuilder)
+```
+
+```cs
+public async Task<ErrorOr<TValue>> FailIfAsync(Func<TValue, Task<bool>> onValue, Func<TValue, Task<Error>> errorBuilder)
+```
+
+```cs
+public static async Task<ErrorOr<TValue>> FailIf<TValue>(
+    this Task<ErrorOr<TValue>> errorOr,
+    Func<TValue, bool> onValue,
+    Func<TValue, Error> errorBuilder)
+```
+
+```cs
+public static async Task<ErrorOr<TValue>> FailIfAsync<TValue>(
+    this Task<ErrorOr<TValue>> errorOr,
+    Func<TValue, Task<bool>> onValue,
+    Func<TValue, Task<Error>> errorBuilder)
+```
+
+Value can now be used to build the error:
+
+```cs
+ErrorOr<int> result = errorOrInt
+    .FailIf(num => num > 3, (num) => Error.Failure(description: $"{num} is greater than 3"));
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,62 +74,62 @@ errorOr.FailIf(x => x > 0, Error.Failure());
 
 - (#94, #95) Added missing async versions of `FailIf` methods (thanks [@MGREMY](https://github.com/MGREMY)!)
 
-```cs
-public async Task<ErrorOr<TValue>> FailIfAsync(Func<TValue, Task<bool>> onValue, Error error)
-```
+    ```cs
+    public async Task<ErrorOr<TValue>> FailIfAsync(Func<TValue, Task<bool>> onValue, Error error)
+    ```
 
-```cs
-public static async Task<ErrorOr<TValue>> FailIf<TValue>(
-    this Task<ErrorOr<TValue>> errorOr,
-    Func<TValue, bool> onValue,
-    Error error)
-```
+    ```cs
+    public static async Task<ErrorOr<TValue>> FailIf<TValue>(
+        this Task<ErrorOr<TValue>> errorOr,
+        Func<TValue, bool> onValue,
+        Error error)
+    ```
 
-```cs
-public static async Task<ErrorOr<TValue>> FailIfAsync<TValue>(
-    this Task<ErrorOr<TValue>> errorOr,
-    Func<TValue, Task<bool>> onValue,
-    Error error)
-```
+    ```cs
+    public static async Task<ErrorOr<TValue>> FailIfAsync<TValue>(
+        this Task<ErrorOr<TValue>> errorOr,
+        Func<TValue, Task<bool>> onValue,
+        Error error)
+    ```
 
 - (#104) Support for .NET 8 was added
 
 - (#109, #111) Added `FailIf` method overloads that allow to use value in error definition using `Func<TValue, Error>` error builder (thanks [@ahmtsen](https://github.com/ahmtsen)!)
 
-```cs
-public ErrorOr<TValue> FailIf(Func<TValue, bool> onValue, Func<TValue, Error> errorBuilder)
-```
+    ```cs
+    public ErrorOr<TValue> FailIf(Func<TValue, bool> onValue, Func<TValue, Error> errorBuilder)
+    ```
 
-```cs
-public async Task<ErrorOr<TValue>> FailIfAsync(Func<TValue, Task<bool>> onValue, Func<TValue, Task<Error>> errorBuilder)
-```
+    ```cs
+    public async Task<ErrorOr<TValue>> FailIfAsync(Func<TValue, Task<bool>> onValue, Func<TValue, Task<Error>> errorBuilder)
+    ```
 
-```cs
-public static async Task<ErrorOr<TValue>> FailIf<TValue>(
-    this Task<ErrorOr<TValue>> errorOr,
-    Func<TValue, bool> onValue,
-    Func<TValue, Error> errorBuilder)
-```
+    ```cs
+    public static async Task<ErrorOr<TValue>> FailIf<TValue>(
+        this Task<ErrorOr<TValue>> errorOr,
+        Func<TValue, bool> onValue,
+        Func<TValue, Error> errorBuilder)
+    ```
 
-```cs
-public static async Task<ErrorOr<TValue>> FailIfAsync<TValue>(
-    this Task<ErrorOr<TValue>> errorOr,
-    Func<TValue, Task<bool>> onValue,
-    Func<TValue, Task<Error>> errorBuilder)
-```
+    ```cs
+    public static async Task<ErrorOr<TValue>> FailIfAsync<TValue>(
+        this Task<ErrorOr<TValue>> errorOr,
+        Func<TValue, Task<bool>> onValue,
+        Func<TValue, Task<Error>> errorBuilder)
+    ```
 
-Value can now be used to build the error:
+    Value can now be used to build the error:
 
-```cs
-ErrorOr<int> result = errorOrInt
-    .FailIf(num => num > 3, (num) => Error.Failure(description: $"{num} is greater than 3"));
-```
+    ```cs
+    ErrorOr<int> result = errorOrInt
+        .FailIf(num => num > 3, (num) => Error.Failure(description: $"{num} is greater than 3"));
+    ```
 
 ### Fixed
 
 - (#85, #97) `ErrorOr` turned into Value Object by reimplementing `Equals` and `GetHashCode` methods
 
-New dependency was introduced to [Microsoft.Bcl.HashCode](https://www.nuget.org/packages/Microsoft.Bcl.HashCode) and development dependency was introduced to [Nullable](https://www.nuget.org/packages/Nullable)
+    New dependency was introduced to [Microsoft.Bcl.HashCode](https://www.nuget.org/packages/Microsoft.Bcl.HashCode) and development dependency was introduced to [Nullable](https://www.nuget.org/packages/Nullable)
 
 ### Optimized
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,14 @@ errorOr.FailIf(x => x > 0, Error.Failure());
 
 - (#104) Support for .NET 6 was removed
 
+- (#105) Invalid use of library now throws exception instead of return errors
+
+    Following actions now throws `InvalidOperationException`:
+
+    1. Default `ErrorOr` constructor invocation.
+    2. Accessing `ErrorOr.Errors` and `ErrorOr.FirstError` on success result.
+    3. Accessing `ErrorOr.Value` on result with errors.
+
 ### Added
 
 - (#94, #95) Added missing async versions of `FailIf` methods (thanks [@MGREMY](https://github.com/MGREMY)!)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,3 +122,7 @@ ErrorOr<int> result = errorOrInt
 - (#85, #97) `ErrorOr` turned into Value Object by reimplementing `Equals` and `GetHashCode` methods
 
 New dependency was introduced to [Microsoft.Bcl.HashCode](https://www.nuget.org/packages/Microsoft.Bcl.HashCode) and development dependency was introduced to [Nullable](https://www.nuget.org/packages/Nullable)
+
+### Optimized
+
+- (#98, #99) Memory consumption optimized by moving static empty errors lists from generic struct into non-generic class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project are documented in this file.
 
 ### Added
 
-- [#94](https://github.com/amantinband/error-or/issues/94), [#95](https://github.com/amantinband/error-or/pull/95) Added missing async versions of `FailIf` methods (thanks [@MGREMY](https://github.com/MGREMY)!)
+- [#94](https://github.com/amantinband/error-or/issues/94), [#95](https://github.com/amantinband/error-or/pull/95) Added missing async versions of `FailIf` methods
 
     ```cs
     public async Task<ErrorOr<TValue>> FailIfAsync(Func<TValue, Task<bool>> onValue, Error error)
@@ -40,7 +40,7 @@ All notable changes to this project are documented in this file.
 
 - [#104](https://github.com/amantinband/error-or/pull/104) Support for .NET 8 was added
 
-- [#109](https://github.com/amantinband/error-or/issues/109), [#111](https://github.com/amantinband/error-or/pull/111) Added `FailIf` method overloads that allow to use value in error definition using `Func<TValue, Error>` error builder (thanks [@ahmtsen](https://github.com/ahmtsen)!)
+- [#109](https://github.com/amantinband/error-or/issues/109), [#111](https://github.com/amantinband/error-or/pull/111) Added `FailIf` method overloads that allow to use value in error definition using `Func<TValue, Error>` error builder
 
     ```cs
     public ErrorOr<TValue> FailIf(Func<TValue, bool> onValue, Func<TValue, Error> errorBuilder)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project are documented in this file.
 
 - `ToErrorOr`
 
-## [2.0.0] - 2024-03-26
+## [2.0.1] - 2024-03-26
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,21 @@ All notable changes to this project are documented in this file.
         .FailIf(num => num > 3, (num) => Error.Failure(description: $"{num} is greater than 3"));
     ```
 
+- [#117](https://github.com/amantinband/error-or/pull/117) Added `ElseDo` and `ElseDoAsync` methods
+
+    Actions returning no result can now be called when `IsError` is true.
+
+    ```cs
+    ErrorOr<string> foo = result
+        .Else(errors => Error.Unexpected())
+        .ElseDo(error => Console.WriteLine(error.FirstError.Description));
+    ```
+
+    ```cs
+    ErrorOr<string> foo = await result
+        .ElseDoAsync(HandleErrorAsync);
+    ```
+
 ### Fixed
 
 - [#85](https://github.com/amantinband/error-or/issues/85), [#97](https://github.com/amantinband/error-or/pull/97) `ErrorOr` turned into Value Object by reimplementing `Equals` and `GetHashCode` methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,8 @@ All notable changes to this project are documented in this file.
     ErrorOr<int> errorOrPerson = ErrorOr<int>.From([Error.Validation(), Error.Validation()]);
     ```
 
+- [#149](https://github.com/amantinband/error-or/pull/149) Added `Else`/`ElseAsync` overloads returning `ErrorOr`
+
 ### Fixed
 
 - [#85](https://github.com/amantinband/error-or/issues/85), [#97](https://github.com/amantinband/error-or/pull/97) `ErrorOr` turned into Value Object by reimplementing `Equals` and `GetHashCode` methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,10 @@ All notable changes to this project are documented in this file.
 
     New dependency was introduced to [Microsoft.Bcl.HashCode](https://www.nuget.org/packages/Microsoft.Bcl.HashCode) and development dependency was introduced to [Nullable](https://www.nuget.org/packages/Nullable)
 
+- [#150](https://github.com/amantinband/error-or/pull/150) `EmptyErrors.Instance` returns new `List<Error>` instance on each call
+
+    This allows to avoid mutating empty list
+
 ### Optimized
 
 - [#98](https://github.com/amantinband/error-or/issues/98), [#99](https://github.com/amantinband/error-or/pull/99) Memory consumption optimized by moving static empty errors lists from generic struct into non-generic class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,14 @@ All notable changes to this project are documented in this file.
         .ElseDoAsync(HandleErrorAsync);
     ```
 
+- [#122](https://github.com/amantinband/error-or/pull/122) Added `ToErrorOrAsync` method
+
+    Values in `Task` can now be easily converted to `ErrorOr`.
+
+    ```cs
+    ErrorOr<int> result = await Task.FromResult(5).ToErrorOrAsync();
+    ```
+
 ### Fixed
 
 - [#85](https://github.com/amantinband/error-or/issues/85), [#97](https://github.com/amantinband/error-or/pull/97) `ErrorOr` turned into Value Object by reimplementing `Equals` and `GetHashCode` methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,21 @@ All notable changes to this project are documented in this file.
     ErrorOr<int> result = await Task.FromResult(5).ToErrorOrAsync();
     ```
 
+- [#129](https://github.com/amantinband/error-or/pull/129) Added missing `ErrorOrFactory.From` methods
+
+    Now following calls from `README.md` are available
+
+    ```cs
+    ErrorOr<int> result = ErrorOrFactory.From<int>(Error.Unexpected());
+    ErrorOr<int> result = ErrorOrFactory.From<int>([Error.Validation(), Error.Validation()]);
+    ```
+
+    Following call is now obsolete
+
+    ```cs
+    ErrorOr<int> errorOrPerson = ErrorOr<int>.From([Error.Validation(), Error.Validation()]);
+    ```
+
 ### Fixed
 
 - [#85](https://github.com/amantinband/error-or/issues/85), [#97](https://github.com/amantinband/error-or/pull/97) `ErrorOr` turned into Value Object by reimplementing `Equals` and `GetHashCode` methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,10 @@ All notable changes to this project are documented in this file.
 
 - [#98](https://github.com/amantinband/error-or/issues/98), [#99](https://github.com/amantinband/error-or/pull/99) Memory consumption optimized by moving static empty errors lists from generic struct into non-generic class
 
+### Refactored
+
+- [#154](https://github.com/amantinband/error-or/pull/154) Modernized NuGet publish workflow
+
 ## [2.0.1] - 2024-03-26
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,14 @@ All notable changes to this project are documented in this file.
     ErrorOr<int> errorOrPerson = ErrorOr<int>.From([Error.Validation(), Error.Validation()]);
     ```
 
+- [#133](https://github.com/amantinband/error-or/pull/133) Added missing collection expression support
+
+    Now following call from `README.md` is available
+
+    ```cs
+    ErrorOr<int> result = [Error.Validation(), Error.Validation()];
+    ```
+
 - [#149](https://github.com/amantinband/error-or/pull/149) Added `Else`/`ElseAsync` overloads returning `ErrorOr`
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented in this file.
 
-## [3.0.0-alpha.0] - to be released
+## [3.0.0] - to be released
 
 ### Breaking Changes
 
@@ -11,7 +11,6 @@ All notable changes to this project are documented in this file.
 - [#105](https://github.com/amantinband/error-or/pull/105) Invalid use of library now throws exception instead of return errors
 
     Following actions now throws `InvalidOperationException`:
-
     1. Default `ErrorOr` constructor invocation.
     2. Accessing `ErrorOr.Errors` and `ErrorOr.FirstError` on success result.
     3. Accessing `ErrorOr.Value` on result with errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,7 @@
 
 All notable changes to this project are documented in this file.
 
-## [3.0.0] - to be released
-
-### Breaking Changes
-
-- [#104](https://github.com/amantinband/error-or/pull/104) Support for .NET 6 was removed
-
-- [#105](https://github.com/amantinband/error-or/pull/105) Invalid use of library now throws exception instead of return errors
-
-    Following actions now throws `InvalidOperationException`:
-    1. Default `ErrorOr` constructor invocation.
-    2. Accessing `ErrorOr.Errors` and `ErrorOr.FirstError` on success result.
-    3. Accessing `ErrorOr.Value` on result with errors.
+## [2.1.1] - to be released
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,8 @@ All notable changes to this project are documented in this file.
 
 - [#98](https://github.com/amantinband/error-or/issues/98), [#99](https://github.com/amantinband/error-or/pull/99) Memory consumption optimized by moving static empty errors lists from generic struct into non-generic class
 
+- [#128](https://github.com/error-or/error-or/pull/128) Removed unneccessary null check from `ErrorOr(List<Error>)` constructor
+
 ### Refactored
 
 - [#154](https://github.com/amantinband/error-or/pull/154) Modernized NuGet publish workflow

--- a/src/ErrorOr/ErrorOr.ImplicitConverters.cs
+++ b/src/ErrorOr/ErrorOr.ImplicitConverters.cs
@@ -5,41 +5,20 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> from a value.
     /// </summary>
-    public static implicit operator ErrorOr<TValue>(TValue value)
-    {
-        return new ErrorOr<TValue>(value);
-    }
+    public static implicit operator ErrorOr<TValue>(TValue value) => new(value);
 
     /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> from an error.
     /// </summary>
-    public static implicit operator ErrorOr<TValue>(Error error)
-    {
-        return new ErrorOr<TValue>(error);
-    }
+    public static implicit operator ErrorOr<TValue>(Error error) => new(error);
 
     /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> from a list of errors.
     /// </summary>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="errors" /> is an empty list.</exception>
-    public static implicit operator ErrorOr<TValue>(List<Error> errors)
-    {
-        return new ErrorOr<TValue>(errors);
-    }
+    public static implicit operator ErrorOr<TValue>(List<Error> errors) => new(errors);
 
     /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> from a list of errors.
     /// </summary>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="errors" /> is an empty array.</exception>
-    public static implicit operator ErrorOr<TValue>(Error[] errors)
-    {
-        if (errors is null)
-        {
-            throw new ArgumentNullException(nameof(errors));
-        }
-
-        return new ErrorOr<TValue>([.. errors]);
-    }
+    public static implicit operator ErrorOr<TValue>(Error[] errors) => errors is null ? default : new ErrorOr<TValue>([.. errors]);
 }

--- a/src/ErrorOr/ErrorOr.cs
+++ b/src/ErrorOr/ErrorOr.cs
@@ -11,15 +11,6 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     private readonly TValue? _value = default;
     private readonly List<Error>? _errors = null;
 
-    /// <summary>
-    /// Prevents a default <see cref="ErrorOr"/> struct from being created.
-    /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown when this method is called.</exception>
-    public ErrorOr()
-    {
-        throw new InvalidOperationException("Default construction of ErrorOr<TValue> is invalid. Please use provided factory methods to instantiate.");
-    }
-
     private ErrorOr(Error error)
     {
         _errors = [error];
@@ -62,42 +53,28 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// <summary>
     /// Gets the list of errors. If the state is not error, the list will contain a single error representing the state.
     /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown when no errors are present.</exception>
-    public List<Error> Errors => IsError ? _errors : throw new InvalidOperationException("The Errors property cannot be accessed when no errors have been recorded. Check IsError before accessing Errors.");
+    public List<Error> Errors => IsError ? _errors : KnownErrors.CachedNoErrorsList;
 
     /// <summary>
     /// Gets the list of errors. If the state is not error, the list will be empty.
     /// </summary>
-    public List<Error> ErrorsOrEmptyList => IsError ? _errors : EmptyErrors.Instance;
+    public List<Error> ErrorsOrEmptyList => IsError ? _errors : KnownErrors.CachedEmptyErrorsList;
 
     /// <summary>
     /// Gets the value.
     /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown when no value is present.</exception>
-    public TValue Value
-    {
-        get
-        {
-            if (IsError)
-            {
-                throw new InvalidOperationException("The Value property cannot be accessed when errors have been recorded. Check IsError before accessing Value.");
-            }
-
-            return _value;
-        }
-    }
+    public TValue Value => _value!;
 
     /// <summary>
     /// Gets the first error.
     /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown when no errors are present.</exception>
     public Error FirstError
     {
         get
         {
             if (!IsError)
             {
-                throw new InvalidOperationException("The FirstError property cannot be accessed when no errors have been recorded. Check IsError before accessing FirstError.");
+                return KnownErrors.NoFirstError;
             }
 
             return _errors[0];

--- a/src/ErrorOr/ErrorOr.cs
+++ b/src/ErrorOr/ErrorOr.cs
@@ -11,35 +11,11 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     private readonly TValue? _value = default;
     private readonly List<Error>? _errors = null;
 
-    private ErrorOr(Error error)
-    {
-        _errors = [error];
-    }
+    private ErrorOr(TValue value) => _value = value;
 
-    private ErrorOr(List<Error> errors)
-    {
-        if (errors is null)
-        {
-            throw new ArgumentNullException(nameof(errors));
-        }
+    private ErrorOr(Error error) => _errors = [error];
 
-        if (errors.Count == 0)
-        {
-            throw new ArgumentException("Cannot create an ErrorOr<TValue> from an empty collection of errors. Provide at least one error.", nameof(errors));
-        }
-
-        _errors = errors;
-    }
-
-    private ErrorOr(TValue value)
-    {
-        if (value is null)
-        {
-            throw new ArgumentNullException(nameof(value));
-        }
-
-        _value = value;
-    }
+    private ErrorOr(List<Error> errors) => _errors = errors?.Count == 0 ? null : errors;
 
     /// <summary>
     /// Gets a value indicating whether the state is error.

--- a/src/Errors/KnownErrors.cs
+++ b/src/Errors/KnownErrors.cs
@@ -1,0 +1,16 @@
+﻿namespace ErrorOr;
+
+internal static class KnownErrors
+{
+    public static Error NoFirstError { get; } = Error.Unexpected(
+        code: "ErrorOr.NoFirstError",
+        description: "First error cannot be retrieved from a successful ErrorOr.");
+
+    public static Error NoErrors { get; } = Error.Unexpected(
+        code: "ErrorOr.NoErrors",
+        description: "Error list cannot be retrieved from a successful ErrorOr.");
+
+    public static List<Error> CachedNoErrorsList { get; } = new (1) { NoErrors };
+
+    public static List<Error> CachedEmptyErrorsList { get; } = new (0);
+}

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -561,29 +561,152 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
-    public void CreateErrorOr_WhenNullIsPassedAsErrorsList_ShouldThrowArgumentNullException()
+    public void ImplicitCastNullValue_WhenAccessingValue_ShouldReturnNull()
     {
-        Func<ErrorOr<int>> act = () => default(List<Error>)!;
+        // Arrange
+        ErrorOr<int?> errorOrInt = default(int?);
 
-        act.Should().ThrowExactly<ArgumentNullException>()
-           .And.ParamName.Should().Be("errors");
+        // Act & Assert
+        errorOrInt.IsError.Should().BeFalse();
+        errorOrInt.Value.Should().BeNull();
     }
 
     [Fact]
-    public void CreateErrorOr_WhenNullIsPassedAsErrorsArray_ShouldThrowArgumentNullException()
+    public void ImplicitCastNullValue_WhenAccessingErrors_ShouldReturnUnexpected()
     {
-        Func<ErrorOr<int>> act = () => default(Error[])!;
+        // Arrange
+        ErrorOr<int?> errorOrInt = default(int?);
 
-        act.Should().ThrowExactly<ArgumentNullException>()
-           .And.ParamName.Should().Be("errors");
+        // Act
+        List<Error> errors = errorOrInt.Errors;
+
+        // Assert
+        errors.Should().ContainSingle().Which.Type.Should().Be(ErrorType.Unexpected);
     }
 
     [Fact]
-    public void CreateErrorOr_WhenValueIsNull_ShouldThrowArgumentNullException()
+    public void ImplicitCastNullValue_WhenAccessingErrorsOrEmptyList_ShouldReturnEmptyList()
     {
-        Func<ErrorOr<int?>> act = () => default(int?);
+        // Arrange
+        ErrorOr<int?> errorOrInt = default(int?);
 
-        act.Should().ThrowExactly<ArgumentNullException>()
-           .And.ParamName.Should().Be("value");
+        // Act
+        List<Error> errors = errorOrInt.ErrorsOrEmptyList;
+
+        // Assert
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ImplicitCastNullValue_WhenAccessingFirstError_ShouldReturnUnexpected()
+    {
+        // Arrange
+        ErrorOr<int?> errorOrInt = default(int?);
+
+        // Act
+        Error firstError = errorOrInt.FirstError;
+
+        // Assert
+        firstError.Type.Should().Be(ErrorType.Unexpected);
+    }
+
+    [Fact]
+    public void ImplicitCastNullErrorList_WhenAccessingValue_ShouldReturnDefault()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = default(List<Error>)!;
+
+        // Act & Assert
+        errorOrInt.IsError.Should().BeFalse();
+        errorOrInt.Value.Should().Be(default);
+    }
+
+    [Fact]
+    public void ImplicitCastNullErrorList_WhenAccessingErrors_ShouldReturnUnexpected()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = default(List<Error>)!;
+
+        // Act
+        List<Error> errors = errorOrInt.Errors;
+
+        // Assert
+        errors.Should().ContainSingle().Which.Type.Should().Be(ErrorType.Unexpected);
+    }
+
+    [Fact]
+    public void ImplicitCastNullErrorList_WhenAccessingErrorsOrEmptyList_ShouldReturnEmptyList()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = default(List<Error>)!;
+
+        // Act
+        List<Error> errors = errorOrInt.ErrorsOrEmptyList;
+
+        // Assert
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ImplicitCastNullErrorList_WhenAccessingFirstError_ShouldReturnUnexpected()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = default(List<Error>)!;
+
+        // Act
+        Error firstError = errorOrInt.FirstError;
+
+        // Assert
+        firstError.Type.Should().Be(ErrorType.Unexpected);
+    }
+
+    [Fact]
+    public void ImplicitCastNullErrorArray_WhenAccessingValue_ShouldReturnDefault()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = default(Error[])!;
+
+        // Act & Assert
+        errorOrInt.IsError.Should().BeFalse();
+        errorOrInt.Value.Should().Be(default);
+    }
+
+    [Fact]
+    public void ImplicitCastNullErrorArray_WhenAccessingErrors_ShouldReturnUnexpected()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = default(Error[])!;
+
+        // Act
+        List<Error> errors = errorOrInt.Errors;
+
+        // Assert
+        errors.Should().ContainSingle().Which.Type.Should().Be(ErrorType.Unexpected);
+    }
+
+    [Fact]
+    public void ImplicitCastNullErrorArray_WhenAccessingErrorsOrEmptyList_ShouldReturnEmptyList()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = default(Error[])!;
+
+        // Act
+        List<Error> errors = errorOrInt.ErrorsOrEmptyList;
+
+        // Assert
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ImplicitCastNullErrorArray_WhenAccessingFirstError_ShouldReturnUnexpected()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = default(Error[])!;
+
+        // Act
+        Error firstError = errorOrInt.FirstError;
+
+        // Assert
+        firstError.Type.Should().Be(ErrorType.Unexpected);
     }
 }

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -461,27 +461,103 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
-    public void CreateErrorOr_WhenEmptyErrorsList_ShouldThrow()
+    public void ImplicitCastEmptyErrorList_WhenAccessingValue_ShouldReturnDefault()
     {
-        // Act
-        Func<ErrorOr<int>> errorOrInt = () => new List<Error>();
+        // Arrange
+        ErrorOr<int> errorOrInt = new List<Error>();
 
-        // Assert
-        var exception = errorOrInt.Should().ThrowExactly<ArgumentException>().Which;
-        exception.Message.Should().Be("Cannot create an ErrorOr<TValue> from an empty collection of errors. Provide at least one error. (Parameter 'errors')");
-        exception.ParamName.Should().Be("errors");
+        // Act & Assert
+        errorOrInt.IsError.Should().BeFalse();
+        errorOrInt.Value.Should().Be(default);
     }
 
     [Fact]
-    public void CreateErrorOr_WhenEmptyErrorsArray_ShouldThrow()
+    public void ImplicitCastEmptyErrorList_WhenAccessingErrors_ShouldReturnUnexpected()
     {
+        // Arrange
+        ErrorOr<int> errorOrInt = new List<Error>();
+
         // Act
-        Func<ErrorOr<int>> errorOrInt = () => Array.Empty<Error>();
+        List<Error> errors = errorOrInt.Errors;
 
         // Assert
-        var exception = errorOrInt.Should().ThrowExactly<ArgumentException>().Which;
-        exception.Message.Should().Be("Cannot create an ErrorOr<TValue> from an empty collection of errors. Provide at least one error. (Parameter 'errors')");
-        exception.ParamName.Should().Be("errors");
+        errors.Should().ContainSingle().Which.Type.Should().Be(ErrorType.Unexpected);
+    }
+
+    [Fact]
+    public void ImplicitCastEmptyErrorList_WhenAccessingErrorsOrEmptyList_ShouldReturnEmptyList()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = new List<Error>();
+
+        // Act
+        List<Error> errors = errorOrInt.ErrorsOrEmptyList;
+
+        // Assert
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ImplicitCastEmptyErrorList_WhenAccessingFirstError_ShouldReturnUnexpected()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = new List<Error>();
+
+        // Act
+        Error firstError = errorOrInt.FirstError;
+
+        // Assert
+        firstError.Type.Should().Be(ErrorType.Unexpected);
+    }
+
+    [Fact]
+    public void ImplicitCastEmptyErrorArray_WhenAccessingValue_ShouldReturnDefault()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = Array.Empty<Error>();
+
+        // Act & Assert
+        errorOrInt.IsError.Should().BeFalse();
+        errorOrInt.Value.Should().Be(default);
+    }
+
+    [Fact]
+    public void ImplicitCastEmptyErrorArray_WhenAccessingErrors_ShouldReturnUnexpected()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = Array.Empty<Error>();
+
+        // Act
+        List<Error> errors = errorOrInt.Errors;
+
+        // Assert
+        errors.Should().ContainSingle().Which.Type.Should().Be(ErrorType.Unexpected);
+    }
+
+    [Fact]
+    public void ImplicitCastEmptyErrorArray_WhenAccessingErrorsOrEmptyList_ShouldReturnEmptyList()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = Array.Empty<Error>();
+
+        // Act
+        List<Error> errors = errorOrInt.ErrorsOrEmptyList;
+
+        // Assert
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ImplicitCastEmptyErrorArray_WhenAccessingFirstError_ShouldReturnUnexpected()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = Array.Empty<Error>();
+
+        // Act
+        Error firstError = errorOrInt.FirstError;
+
+        // Assert
+        firstError.Type.Should().Be(ErrorType.Unexpected);
     }
 
     [Fact]

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -262,7 +262,7 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
-    public void ImplicitCastError_WhenAccessingValue_ShouldReturnDefault()
+    public void ImplicitCastSingleError_WhenAccessingValue_ShouldReturnDefault()
     {
         // Arrange
         ErrorOr<Person> errorOrPerson = Error.Validation("User.Name", "Name is too short");

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -360,6 +360,7 @@ public class ErrorOrInstantiationTests
         errorOrPerson.FirstError.Should().Be(errors[0]);
     }
 
+#pragma warning disable SA1129 // Do not use default value type constructor
     [Fact]
     public void CreateWithEmptyConstructor_WhenAccessingValue_ShouldReturnDefault()
     {
@@ -409,6 +410,7 @@ public class ErrorOrInstantiationTests
         // Assert
         firstError.Type.Should().Be(ErrorType.Unexpected);
     }
+#pragma warning restore SA1129 // Do not use default value type constructor
 
     [Fact]
     public void CreateWithDefault_WhenAccessingValue_ShouldReturnDefault()

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -83,7 +83,7 @@ public class ErrorOrInstantiationTests
     public void CreateFromErrorList_WhenAccessingErrors_ShouldReturnErrorList()
     {
         // Arrange
-        List<Error> errors = new() { Error.Validation("User.Name", "Name is too short") };
+        List<Error> errors = [Error.Validation("User.Name", "Name is too short")];
         ErrorOr<Person> errorOrPerson = ErrorOr<Person>.From(errors);
 
         // Act & Assert
@@ -110,7 +110,7 @@ public class ErrorOrInstantiationTests
     public void CreateFromErrorList_WhenAccessingErrorsOrEmptyList_ShouldReturnErrorList()
     {
         // Arrange
-        List<Error> errors = new() { Error.Validation("User.Name", "Name is too short") };
+        List<Error> errors = [Error.Validation("User.Name", "Name is too short")];
         ErrorOr<Person> errorOrPerson = ErrorOr<Person>.From(errors);
 
         // Act & Assert
@@ -136,7 +136,7 @@ public class ErrorOrInstantiationTests
     public void CreateFromErrorList_WhenAccessingValue_ShouldReturnDefault()
     {
         // Arrange
-        List<Error> errors = new() { Error.Validation("User.Name", "Name is too short") };
+        List<Error> errors = [Error.Validation("User.Name", "Name is too short")];
         ErrorOr<Person> errorOrPerson = ErrorOr<Person>.From(errors);
 
         // Act
@@ -292,11 +292,11 @@ public class ErrorOrInstantiationTests
     public void ImplicitCastErrorList_WhenAccessingErrors_ShouldReturnErrorList()
     {
         // Arrange
-        List<Error> errors = new()
-        {
+        List<Error> errors =
+        [
             Error.Validation("User.Name", "Name is too short"),
             Error.Validation("User.Age", "User is too young"),
-        };
+        ];
 
         // Act
         ErrorOr<Person> errorOrPerson = errors;
@@ -328,11 +328,11 @@ public class ErrorOrInstantiationTests
     public void ImplicitCastErrorList_WhenAccessingFirstError_ShouldReturnFirstError()
     {
         // Arrange
-        List<Error> errors = new()
-        {
+        List<Error> errors =
+        [
             Error.Validation("User.Name", "Name is too short"),
             Error.Validation("User.Age", "User is too young"),
-        };
+        ];
 
         // Act
         ErrorOr<Person> errorOrPerson = errors;

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -411,6 +411,56 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
+    public void CreateWithDefault_WhenAccessingValue_ShouldReturnDefault()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = default;
+
+        // Act & Assert
+        errorOrInt.IsError.Should().BeFalse();
+        errorOrInt.Value.Should().Be(default);
+    }
+
+    [Fact]
+    public void CreateWithDefault_WhenAccessingErrors_ShouldReturnUnexpected()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = default;
+
+        // Act
+        List<Error> errors = errorOrInt.Errors;
+
+        // Assert
+        errors.Should().ContainSingle().Which.Type.Should().Be(ErrorType.Unexpected);
+    }
+
+    [Fact]
+    public void CreateWithDefault_WhenAccessingErrorsOrEmptyList_ShouldReturnEmptyList()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = default;
+
+        // Act
+        List<Error> errors = errorOrInt.ErrorsOrEmptyList;
+
+        // Assert
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CreateWithDefault_WhenAccessingFirstError_ShouldReturnUnexpected()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = default;
+
+        // Act
+        Error firstError = errorOrInt.FirstError;
+
+        // Assert
+        firstError.Type.Should().Be(ErrorType.Unexpected);
+    }
+
+    [Fact]
     public void CreateErrorOr_WhenEmptyErrorsList_ShouldThrow()
     {
         // Act

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -361,13 +361,53 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
-    public void CreateErrorOr_WhenUsingEmptyConstructor_ShouldThrow()
+    public void CreateWithEmptyConstructor_WhenAccessingValue_ShouldReturnDefault()
     {
+        // Arrange
+        ErrorOr<int> errorOrInt = new ErrorOr<int>();
+
+        // Act &Assert
+        errorOrInt.IsError.Should().BeFalse();
+        errorOrInt.Value.Should().Be(default);
+    }
+
+    [Fact]
+    public void CreateWithEmptyConstructor_WhenAccessingErrors_ShouldReturnUnexpected()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = new ErrorOr<int>();
+
         // Act
-        Func<ErrorOr<int>> action = () => new ErrorOr<int>();
+        List<Error> errors = errorOrInt.Errors;
 
         // Assert
-        action.Should().ThrowExactly<InvalidOperationException>();
+        errors.Should().ContainSingle().Which.Type.Should().Be(ErrorType.Unexpected);
+    }
+
+    [Fact]
+    public void CreateWithEmptyConstructor_WhenAccessingErrorsOrEmptyList_ShouldReturnEmptyList()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = new ErrorOr<int>();
+
+        // Act
+        List<Error> errors = errorOrInt.ErrorsOrEmptyList;
+
+        // Assert
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CreateWithEmptyConstructor_WhenAccessingFirstError_ShouldReturnUnexpected()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = new ErrorOr<int>();
+
+        // Act
+        Error firstError = errorOrInt.FirstError;
+
+        // Assert
+        firstError.Type.Should().Be(ErrorType.Unexpected);
     }
 
     [Fact]

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -23,17 +23,17 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
-    public void CreateFromValue_WhenAccessingErrors_ShouldThrow()
+    public void CreateFromValue_WhenAccessingErrors_ShouldReturnUnexpectedError()
     {
         // Arrange
         IEnumerable<string> value = ["value"];
         ErrorOr<IEnumerable<string>> errorOrPerson = ErrorOrFactory.From(value);
 
         // Act
-        Func<List<Error>> action = () => errorOrPerson.Errors;
+        List<Error> errors = errorOrPerson.Errors;
 
         // Assert
-        action.Should().ThrowExactly<InvalidOperationException>();
+        errors.Should().ContainSingle().Which.Type.Should().Be(ErrorType.Unexpected);
     }
 
     [Fact]
@@ -51,17 +51,17 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
-    public void CreateFromValue_WhenAccessingFirstError_ShouldThrow()
+    public void CreateFromValue_WhenAccessingFirstError_ShouldReturnUnexpectedError()
     {
         // Arrange
         IEnumerable<string> value = ["value"];
         ErrorOr<IEnumerable<string>> errorOrPerson = ErrorOrFactory.From(value);
 
         // Act
-        Func<Error> action = () => errorOrPerson.FirstError;
+        Error firstError = errorOrPerson.FirstError;
 
         // Assert
-        action.Should().ThrowExactly<InvalidOperationException>();
+        firstError.Type.Should().Be(ErrorType.Unexpected);
     }
 
     [Fact]
@@ -119,33 +119,31 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
-    public void CreateFromErrorList_UsingFactory_WhenAccessingValue_ShouldThrowInvalidOperationException()
+    public void CreateFromErrorList_UsingFactory_WhenAccessingValue_ShouldReturnDefault()
     {
         // Arrange
         ErrorOr<Person> errorOrPerson = ErrorOrFactory.From<Person>([Error.Validation("User.Name", "Name is too short")]);
 
         // Act
-        var act = () => errorOrPerson.Value;
+        Person value = errorOrPerson.Value;
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
-           .And.Message.Should().Be("The Value property cannot be accessed when errors have been recorded. Check IsError before accessing Value.");
+        value.Should().Be(default);
     }
 
     [Fact]
     [Obsolete]
-    public void CreateFromErrorList_WhenAccessingValue_ShouldThrowInvalidOperationException()
+    public void CreateFromErrorList_WhenAccessingValue_ShouldReturnDefault()
     {
         // Arrange
         List<Error> errors = new() { Error.Validation("User.Name", "Name is too short") };
         ErrorOr<Person> errorOrPerson = ErrorOr<Person>.From(errors);
 
         // Act
-        var act = () => errorOrPerson.Value;
+        Person value = errorOrPerson.Value;
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
-           .And.Message.Should().Be("The Value property cannot be accessed when errors have been recorded. Check IsError before accessing Value.");
+        value.Should().Be(default);
     }
 
     [Fact]
@@ -189,27 +187,27 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
-    public void ImplicitCastResult_WhenAccessingErrors_ShouldThrow()
+    public void ImplicitCastResult_WhenAccessingErrors_ShouldReturnUnexpectedError()
     {
         ErrorOr<Person> errorOrPerson = new Person("Amichai");
 
         // Act
-        Func<List<Error>> action = () => errorOrPerson.Errors;
+        List<Error> errors = errorOrPerson.Errors;
 
         // Assert
-        action.Should().ThrowExactly<InvalidOperationException>();
+        errors.Should().ContainSingle().Which.Type.Should().Be(ErrorType.Unexpected);
     }
 
     [Fact]
-    public void ImplicitCastResult_WhenAccessingFirstError_ShouldThrow()
+    public void ImplicitCastResult_WhenAccessingFirstError_ShouldReturnUnexpectedError()
     {
         ErrorOr<Person> errorOrPerson = new Person("Amichai");
 
         // Act
-        Func<Error> action = () => errorOrPerson.FirstError;
+        Error firstError = errorOrPerson.FirstError;
 
         // Assert
-        action.Should().ThrowExactly<InvalidOperationException>();
+        firstError.Type.Should().Be(ErrorType.Unexpected);
     }
 
     [Fact]
@@ -264,17 +262,16 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
-    public void ImplicitCastError_WhenAccessingValue_ShouldThrowInvalidOperationException()
+    public void ImplicitCastError_WhenAccessingValue_ShouldReturnDefault()
     {
         // Arrange
         ErrorOr<Person> errorOrPerson = Error.Validation("User.Name", "Name is too short");
 
         // Act
-        var act = () => errorOrPerson.Value;
+        Person value = errorOrPerson.Value;
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
-           .And.Message.Should().Be("The Value property cannot be accessed when errors have been recorded. Check IsError before accessing Value.");
+        value.Should().Be(default);
     }
 
     [Fact]


### PR DESCRIPTION
This pull requests contains CHANGELOG supplementation from #127 and reverts backwards incompatible changes regarding:
 - [#106] throwing exceptions on invalid library usage
 - [#104] removal of .NET 6 support

Reverted was only significant changes, not refactorings nor renames.

This PR is only for the purpose of fostering 2.1.0 release. @amantinband please merge if you agree about that it is more value in reverting those changes temporarily. I will reapply those changes soon after 2.1.0 release as a separate PR.

See: #115