### PR TITLE
Bugfix: collection expression support added

### DIFF
--- a/src/ErrorOr.csproj
+++ b/src/ErrorOr.csproj
@@ -26,14 +26,11 @@
     <AdditionalFiles Include="Stylecop.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference
-      Include="Microsoft.Bcl.HashCode"
-      Version="1.1.1"
-      Condition="'$(TargetFramework)' == 'netstandard2.0'"
-    />
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Nullable" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Memory" Version="4.6.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>
 </Project>

--- a/src/ErrorOr/CollectionBuilderAttribute.cs
+++ b/src/ErrorOr/CollectionBuilderAttribute.cs
@@ -1,0 +1,15 @@
+#if !NET8_0_OR_GREATER
+namespace System.Runtime.CompilerServices;
+
+internal sealed class CollectionBuilderAttribute : Attribute
+{
+    public CollectionBuilderAttribute(Type builderType, string methodName)
+    {
+        BuilderType = builderType;
+        MethodName = methodName;
+    }
+
+    public Type BuilderType { get; }
+    public string MethodName { get; }
+}
+#endif

--- a/src/ErrorOr/CollectionExpression.cs
+++ b/src/ErrorOr/CollectionExpression.cs
@@ -1,0 +1,42 @@
+namespace ErrorOr;
+
+/// <summary>
+/// Contains methods supporting collection expressions.
+/// </summary>
+public static class CollectionExpression
+{
+    /// <summary>
+    /// Creates <see cref="ErrorOr{TValue}"/> from read-only span of errors.
+    /// </summary>
+    /// <typeparam name="TValue">Type of value.</typeparam>
+    /// <param name="errors">Read-only span of errors.</param>
+    /// <returns>Error or vale.</returns>
+    /// <remarks>Enables support for collection expressions.</remarks>
+    public static ErrorOr<TValue> CreateErrorOr<TValue>(ReadOnlySpan<Error> errors)
+    {
+        return errors.ToArray();
+    }
+
+    /// <summary>
+    /// Creates <see cref="IErrorOr{TValue}"/> from read-only span of errors.
+    /// </summary>
+    /// <typeparam name="TValue">Type of value.</typeparam>
+    /// <param name="errors">Read-only span of errors.</param>
+    /// <returns>Error or vale.</returns>
+    /// <remarks>Enables support for collection expressions.</remarks>
+    public static IErrorOr<TValue> CreateIErrorOrValue<TValue>(ReadOnlySpan<Error> errors)
+    {
+        return CreateErrorOr<TValue>(errors);
+    }
+
+    /// <summary>
+    /// Creates <see cref="IErrorOr"/> from read-only span of errors.
+    /// </summary>
+    /// <param name="errors">Read-only span of errors.</param>
+    /// <returns>Error or vale.</returns>
+    /// <remarks>Enables support for collection expressions.</remarks>
+    public static IErrorOr CreateIErrorOr(ReadOnlySpan<Error> errors)
+    {
+        return CreateErrorOr<object>(errors);
+    }
+}

--- a/src/ErrorOr/ErrorOr.cs
+++ b/src/ErrorOr/ErrorOr.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace ErrorOr;
 
@@ -6,6 +7,7 @@ namespace ErrorOr;
 /// A discriminated union of errors or a value.
 /// </summary>
 /// <typeparam name="TValue">The type of the underlying <see cref="Value"/>.</typeparam>
+[CollectionBuilder(typeof(CollectionExpression), nameof(CollectionExpression.CreateErrorOr))]
 public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
 {
     private readonly TValue? _value = default;
@@ -103,6 +105,9 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
             return _errors[0];
         }
     }
+
+    /// <inheritdoc/>
+    public IEnumerator<Error> GetEnumerator() => _errors!.GetEnumerator();
 
     /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> from a list of errors.

--- a/src/ErrorOr/IErrorOr.cs
+++ b/src/ErrorOr/IErrorOr.cs
@@ -1,5 +1,8 @@
+using System.Runtime.CompilerServices;
+
 namespace ErrorOr;
 
+[CollectionBuilder(typeof(CollectionExpression), nameof(CollectionExpression.CreateIErrorOrValue))]
 public interface IErrorOr<out TValue> : IErrorOr
 {
     /// <summary>
@@ -14,6 +17,7 @@ public interface IErrorOr<out TValue> : IErrorOr
 /// <remarks>
 /// This interface is intended for use when the underlying type of the <see cref="ErrorOr"/> object is unknown.
 /// </remarks>
+[CollectionBuilder(typeof(CollectionExpression), nameof(CollectionExpression.CreateIErrorOr))]
 public interface IErrorOr
 {
     /// <summary>
@@ -25,4 +29,11 @@ public interface IErrorOr
     /// Gets a value indicating whether the state is error.
     /// </summary>
     bool IsError { get; }
+
+    /// <summary>
+    /// Gets enumerator with <see cref="Error"/> objects.
+    /// </summary>
+    /// <returns>Enunerator of <see cref="Error"/> objects.</returns>
+    /// <remarks>This method is only for the purpose of collection expression support.</remarks>
+    IEnumerator<Error> GetEnumerator();
 }

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -407,4 +407,49 @@ public class ErrorOrInstantiationTests
         act.Should().ThrowExactly<ArgumentNullException>()
            .And.ParamName.Should().Be("value");
     }
+
+    [Fact]
+    public void ErrorOr_FromErrorCollectionExpression_WhenAccessingErrors_ShouldReturnErrorList()
+    {
+        // Arrange
+        var nameTooShort = Error.Validation("User.Name", "Name is too short");
+        var userTooYoung = Error.Validation("User.Age", "User is too young");
+
+        // Act
+        ErrorOr<Person> errorOrPerson = [nameTooShort, userTooYoung];
+
+        // Assert
+        errorOrPerson.IsError.Should().BeTrue();
+        errorOrPerson.Errors.Should().HaveCount(2).And.BeEquivalentTo([nameTooShort, userTooYoung]);
+    }
+
+    [Fact]
+    public void GenericErrorOrInterface_FromErrorCollectionExpression_WhenAccessingErrors_ShouldReturnErrorList()
+    {
+        // Arrange
+        var nameTooShort = Error.Validation("User.Name", "Name is too short");
+        var userTooYoung = Error.Validation("User.Age", "User is too young");
+
+        // Act
+        IErrorOr<Person> errorOrPerson = [nameTooShort, userTooYoung];
+
+        // Assert
+        errorOrPerson.IsError.Should().BeTrue();
+        errorOrPerson.Errors.Should().HaveCount(2).And.BeEquivalentTo([nameTooShort, userTooYoung]);
+    }
+
+    [Fact]
+    public void ErrorOrInterface_FromErrorCollectionExpression_WhenAccessingErrors_ShouldReturnErrorList()
+    {
+        // Arrange
+        var nameTooShort = Error.Validation("User.Name", "Name is too short");
+        var userTooYoung = Error.Validation("User.Age", "User is too young");
+
+        // Act
+        IErrorOr errorOrPerson = [nameTooShort, userTooYoung];
+
+        // Assert
+        errorOrPerson.IsError.Should().BeTrue();
+        errorOrPerson.Errors.Should().HaveCount(2).And.BeEquivalentTo([nameTooShort, userTooYoung]);
+    }
 }


### PR DESCRIPTION
In [README.md](https://github.com/amantinband/error-or?tab=readme-ov-file#using-implicit-conversion) there is example of creating `ErrorOr` form collection of errors using [collection expression](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/collection-expressions) but in library no such feature exist. Here is implementation of this feature.

Examples:
```cs
ErrorOr<int> result = [Error.Validation(), Error.Validation()];
```
```cs
public ErrorOr<int> MultipleErrorsToErrorOr()
{
    return [
        Error.Validation(description: "Invalid Name"),
        Error.Validation(description: "Invalid Last Name")
    ];
}
```