### PR TITLE
Feature: FromAsync and missing ToErrorOrAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,11 +105,53 @@ All notable changes to this project are documented in this file.
     ErrorOr<int> result = [Error.Validation(), Error.Validation()];
     ```
 
+- [#134](https://github.com/error-or/error-or/pull/134) Added `FromAsync` and missing `ToErrorOrAsync` methods
+
+    Added support for `FromAsync` methods.
+
+    ```cs
+    public async Tak<ErrorOr<int>> GetValueAsync()
+    {
+        return await ErrorOrFactory.FromAsync(5);
+    }
+    ```
+
+    ```cs
+    public async Tak<ErrorOr<int>> SingleErrorToErrorOrAsync()
+    {
+        return await ErrorOrFactory.FromAsync<int>(Error.Unexpected());
+    }
+    ```
+
+    ```cs
+    public async Tak<ErrorOr<int>> MultipleErrorsToErrorOrAsync()
+    {
+        return await ErrorOrFactory.FromAsync([
+            Error.Validation(description: "Invalid Name"),
+            Error.Validation(description: "Invalid Last Name")
+        ]);
+    }
+    ```
+
+    Added support for `ToErrorOrAsync` methods from errors:
+
+    ```cs
+    Task<Error> errorTask = Task.FromResult(Error.Validation());
+    ErrorOr<int> result = errorTask.ToErrorOrAsync<int>();
+    ```
+
+    ```cs
+    List<Error> errors = [Error.Unauthorized(), Error.Validation()];
+    Task<List<Error>> errorsTask = Task.FromResult(errors);
+    ErrorOr<int> result = await errorsTask.ToErrorOrAsync<int>();
+    ```
+
 - [#149](https://github.com/amantinband/error-or/pull/149) Added `Else`/`ElseAsync` overloads returning `ErrorOr`
 
 - [#152](https://github.com/amantinband/error-or/pull/152) Added `ThenEnshure` and `ThenEnshureAsync` methods.
-  They are similar to `ThenDo` and `ThenDoAsync`, but they receive a function that can return errors.
-  If no errors are returned, the original value is preserved and the ensure function's success value is ignored.
+
+    They are similar to `ThenDo` and `ThenDoAsync`, but they receive a function that can return errors.
+    If no errors are returned, the original value is preserved and the ensure function's success value is ignored.
 
 - [#159](https://github.com/amantinband/error-or/pull/159) Added `IsSuccess` property to `ErrorOr`
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 [![GitHub contributors](https://img.shields.io/github/contributors/amantinband/error-or)](https://GitHub.com/amantinband/error-or/graphs/contributors/) [![GitHub Stars](https://img.shields.io/github/stars/amantinband/error-or.svg)](https://github.com/amantinband/error-or/stargazers) [![GitHub license](https://img.shields.io/github/license/amantinband/error-or)](https://github.com/amantinband/error-or/blob/main/LICENSE)
 [![codecov](https://codecov.io/gh/amantinband/error-or/branch/main/graph/badge.svg?token=DR2EBIWK7B)](https://codecov.io/gh/amantinband/error-or)
+
 ---
 
 ### A simple, fluent discriminated union of an error or a result
@@ -18,51 +19,51 @@
 
 - [Give it a star ⭐!](#give-it-a-star-)
 - [Getting Started 🏃](#getting-started-)
-  - [Replace throwing exceptions with `ErrorOr<T>`](#replace-throwing-exceptions-with-errorort)
-  - [Support For Multiple Errors](#support-for-multiple-errors)
-  - [Various Functional Methods and Extension Methods](#various-functional-methods-and-extension-methods)
-    - [Real world example](#real-world-example)
-    - [Simple Example with intermediate steps](#simple-example-with-intermediate-steps)
-      - [No Failure](#no-failure)
-      - [Failure](#failure)
+    - [Replace throwing exceptions with `ErrorOr<T>`](#replace-throwing-exceptions-with-errorort)
+    - [Support For Multiple Errors](#support-for-multiple-errors)
+    - [Various Functional Methods and Extension Methods](#various-functional-methods-and-extension-methods)
+        - [Real world example](#real-world-example)
+        - [Simple Example with intermediate steps](#simple-example-with-intermediate-steps)
+            - [No Failure](#no-failure)
+            - [Failure](#failure)
 - [Creating an `ErrorOr` instance](#creating-an-erroror-instance)
-  - [Using implicit conversion](#using-implicit-conversion)
-  - [Using The `ErrorOrFactory`](#using-the-errororfactory)
-  - [Using The `ToErrorOr` Extension Method](#using-the-toerroror-extension-method)
+    - [Using implicit conversion](#using-implicit-conversion)
+    - [Using The `ErrorOrFactory`](#using-the-errororfactory)
+    - [Using The `ToErrorOr` Extension Method](#using-the-toerroror-extension-method)
 - [Properties](#properties)
-  - [`IsError`](#iserror)
-  - [`IsSuccess`](#issuccess)
-  - [`Value`](#value)
-  - [`Errors`](#errors)
-  - [`FirstError`](#firsterror)
-  - [`ErrorsOrEmptyList`](#errorsoremptylist)
+    - [`IsError`](#iserror)
+    - [`IsSuccess`](#issuccess)
+    - [`Value`](#value)
+    - [`Errors`](#errors)
+    - [`FirstError`](#firsterror)
+    - [`ErrorsOrEmptyList`](#errorsoremptylist)
 - [Methods](#methods)
-  - [`Match`](#match)
-    - [`Match`](#match-1)
-    - [`MatchAsync`](#matchasync)
-    - [`MatchFirst`](#matchfirst)
-    - [`MatchFirstAsync`](#matchfirstasync)
-  - [`Switch`](#switch)
-    - [`Switch`](#switch-1)
-    - [`SwitchAsync`](#switchasync)
-    - [`SwitchFirst`](#switchfirst)
-    - [`SwitchFirstAsync`](#switchfirstasync)
-  - [`Then`](#then)
-    - [`Then`](#then-1)
-    - [`ThenAsync`](#thenasync)
-    - [`ThenDo` and `ThenDoAsync`](#thendo-and-thendoasync)
-    - [`ThenEnsure` and `ThenEnsureAsync`](#thenensure-and-thenensureasync)
-    - [Mixing `Then`, `ThenDo`, `ThenAsync`, `ThenDoAsync`](#mixing-then-thendo-thenasync-thendoasync)
-  - [`FailIf`](#failif)
-  - [`Else`](#else)
-    - [`Else`](#else-1)
-    - [`ElseAsync`](#elseasync)
-    - [`ElseDo` and `ElseDoAsync`](#elsedo-and-elsedoasync)
+    - [`Match`](#match)
+        - [`Match`](#match-1)
+        - [`MatchAsync`](#matchasync)
+        - [`MatchFirst`](#matchfirst)
+        - [`MatchFirstAsync`](#matchfirstasync)
+    - [`Switch`](#switch)
+        - [`Switch`](#switch-1)
+        - [`SwitchAsync`](#switchasync)
+        - [`SwitchFirst`](#switchfirst)
+        - [`SwitchFirstAsync`](#switchfirstasync)
+    - [`Then`](#then)
+        - [`Then`](#then-1)
+        - [`ThenAsync`](#thenasync)
+        - [`ThenDo` and `ThenDoAsync`](#thendo-and-thendoasync)
+        - [`ThenEnsure` and `ThenEnsureAsync`](#thenensure-and-thenensureasync)
+        - [Mixing `Then`, `ThenDo`, `ThenAsync`, `ThenDoAsync`](#mixing-then-thendo-thenasync-thendoasync)
+    - [`FailIf`](#failif)
+    - [`Else`](#else)
+        - [`Else`](#else-1)
+        - [`ElseAsync`](#elseasync)
+        - [`ElseDo` and `ElseDoAsync`](#elsedo-and-elsedoasync)
 - [Mixing Features (`Then`, `FailIf`, `Else`, `Switch`, `Match`)](#mixing-features-then-failif-else-switch-match)
 - [Recording Outcomes](#recording-outcomes)
 - [Error Types](#error-types)
-  - [Built in error types](#built-in-error-types)
-  - [Custom error types](#custom-error-types)
+    - [Built in error types](#built-in-error-types)
+    - [Custom error types](#custom-error-types)
 - [Built in result types (`Result.Success`, ..)](#built-in-result-types-resultsuccess-)
 - [Organizing Errors](#organizing-errors)
 - [Mediator + FluentValidation + `ErrorOr` 🤝](#mediator--fluentvalidation--erroror-)
@@ -340,7 +341,14 @@ ErrorOr<int> result = await Task.FromResult(5).ToErrorOrAsync();
 
 ```cs
 ErrorOr<int> result = Error.Unexpected().ToErrorOr<int>();
-ErrorOr<int> result = new[] { Error.Validation(), Error.Validation() }.ToErrorOr<int>();
+ErrorOr<int> result = new[] { Error.Unauthorized(), Error.Validation() }.ToErrorOr<int>();
+
+Task<Error> errorTask = Task.FromResult(Error.Validation());
+ErrorOr<int> result = errorTask.ToErrorOrAsync<int>();
+
+List<Error> errors = [Error.Unauthorized(), Error.Validation()];
+Task<List<Error>> errorsTask = Task.FromResult(errors);
+ErrorOr<int> result = await errorsTask.ToErrorOrAsync<int>();
 ```
 
 # Properties

--- a/README.md
+++ b/README.md
@@ -274,6 +274,12 @@ ErrorOr<int> result = ErrorOrFactory.From<int>([Error.Validation(), Error.Valida
 ```
 
 ```cs
+ErrorOr<int> result = await ErrorOrFactory.FromAsync(5);
+ErrorOr<int> result = await ErrorOrFactory.FromAsync<int>(Error.Unexpected());
+ErrorOr<int> result = await ErrorOrFactory.FromAsync<int>([Error.Validation(), Error.Validation()]);
+```
+
+```cs
 public ErrorOr<int> GetValue()
 {
     return ErrorOrFactory.From(5);
@@ -291,6 +297,30 @@ public ErrorOr<int> SingleErrorToErrorOr()
 public ErrorOr<int> MultipleErrorsToErrorOr()
 {
     return ErrorOrFactory.From([
+        Error.Validation(description: "Invalid Name"),
+        Error.Validation(description: "Invalid Last Name")
+    ]);
+}
+```
+
+```cs
+public async Tak<ErrorOr<int>> GetValueAsync()
+{
+    return await ErrorOrFactory.FromAsync(5);
+}
+```
+
+```cs
+public async Tak<ErrorOr<int>> SingleErrorToErrorOrAsync()
+{
+    return await ErrorOrFactory.FromAsync<int>(Error.Unexpected());
+}
+```
+
+```cs
+public async Tak<ErrorOr<int>> MultipleErrorsToErrorOrAsync()
+{
+    return await ErrorOrFactory.FromAsync([
         Error.Validation(description: "Invalid Name"),
         Error.Validation(description: "Invalid Last Name")
     ]);

--- a/README.md
+++ b/README.md
@@ -342,10 +342,14 @@ ErrorOr<int> result = await Task.FromResult(5).ToErrorOrAsync();
 ```cs
 ErrorOr<int> result = Error.Unexpected().ToErrorOr<int>();
 ErrorOr<int> result = new[] { Error.Unauthorized(), Error.Validation() }.ToErrorOr<int>();
+```
 
+```cs
 Task<Error> errorTask = Task.FromResult(Error.Validation());
 ErrorOr<int> result = errorTask.ToErrorOrAsync<int>();
+```
 
+```cs
 List<Error> errors = [Error.Unauthorized(), Error.Validation()];
 Task<List<Error>> errorsTask = Task.FromResult(errors);
 ErrorOr<int> result = await errorsTask.ToErrorOrAsync<int>();

--- a/src/ErrorOr/ErrorOr.ToErrorOrExtensions.cs
+++ b/src/ErrorOr/ErrorOr.ToErrorOrExtensions.cs
@@ -3,46 +3,85 @@ namespace ErrorOr;
 public static partial class ErrorOrExtensions
 {
     /// <summary>
-    /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given <paramref name="value"/>.
+    /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given value.
     /// </summary>
+    /// <param name="value">The value to create the <see cref="ErrorOr{TValue}"/> instance with.</param>
     public static ErrorOr<TValue> ToErrorOr<TValue>(this TValue value)
     {
         return value;
     }
 
     /// <summary>
-    /// Creates an <see cref="ErrorOr{TValue}"/> instance with the result of the given <see cref="Task{TValue}"/>.
+    /// Creates an awaitable <see cref="ErrorOr{TValue}"/> instance with the result of the given awaitable value.
     /// </summary>
+    /// <param name="value">The awaitable value to create the <see cref="ErrorOr{TValue}"/> instance with.</param>
     public static async Task<ErrorOr<TValue>> ToErrorOrAsync<TValue>(this Task<TValue> value)
     {
-        return await value;
+        return await value.ConfigureAwait(false);
     }
 
     /// <summary>
-    /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given <paramref name="error"/>.
+    /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given error.
     /// </summary>
+    /// <param name="error">The error to create the <see cref="ErrorOr{TValue}"/> instance with.</param>
     public static ErrorOr<TValue> ToErrorOr<TValue>(this Error error)
     {
         return error;
     }
 
     /// <summary>
-    /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given <paramref name="errors"/>.
+    /// Creates an awaitable <see cref="ErrorOr{TValue}"/> instance with the given awaitable error.
     /// </summary>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="errors" /> is an empty list.</exception>
+    /// <param name="error">The awaitable error to create the <see cref="ErrorOr{TValue}"/> instance with.</param>
+    public static async Task<ErrorOr<TValue>> ToErrorOrAsync<TValue>(this Task<Error> error)
+    {
+        return await error.ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given list of errors.
+    /// </summary>
+    /// <param name="errors">The list of errors to create the <see cref="ErrorOr{TValue}"/> instance with.</param>
     public static ErrorOr<TValue> ToErrorOr<TValue>(this List<Error> errors)
     {
         return errors;
     }
 
     /// <summary>
-    /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given <paramref name="errors"/>.
+    /// Creates an awaitable <see cref="ErrorOr{TValue}"/> instance with the given awaitable list of errors.
     /// </summary>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="errors" /> is an empty array.</exception>
-    public static ErrorOr<TValue> ToErrorOr<TValue>(this Error[] errors)
+    /// <param name="errors">The awaitable list of errors to create the <see cref="ErrorOr{TValue}"/> instance with.</param>
+    public static async Task<ErrorOr<TValue>> ToErrorOrAsync<TValue>(this Task<List<Error>> errors)
     {
-        return errors;
+        return await errors.ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given enumeration of errors.
+    /// </summary>
+    /// <param name="errors">The enumeration of errors to create the <see cref="ErrorOr{TValue}"/> instance with.</param>
+    public static ErrorOr<TValue> ToErrorOr<TValue>(this IEnumerable<Error> errors)
+    {
+        return errors.ToList();
+    }
+
+    /// <summary>
+    /// Creates an awaitable <see cref="ErrorOr{TValue}"/> instance with the given awaitable array of errors.
+    /// </summary>
+    /// <param name="errors">The array of errors to create the <see cref="ErrorOr{TValue}"/> instance with.</param>
+    public static async Task<ErrorOr<TValue>> ToErrorOrAsync<TValue>(this Task<Error[]> errors)
+    {
+        var errorArray = await errors.ConfigureAwait(false);
+        return errorArray.ToList();
+    }
+
+    /// <summary>
+    /// Creates an awaitable <see cref="ErrorOr{TValue}"/> instance with the given awaitable enumeration of errors.
+    /// </summary>
+    /// <param name="errors">The enumeration of errors to create the <see cref="ErrorOr{TValue}"/> instance with.</param>
+    public static async Task<ErrorOr<TValue>> ToErrorOrAsync<TValue>(this Task<IEnumerable<Error>> errors)
+    {
+        var errorEnumeration = await errors.ConfigureAwait(false);
+        return errorEnumeration.ToList();
     }
 }

--- a/src/ErrorOr/ErrorOrFactory.cs
+++ b/src/ErrorOr/ErrorOrFactory.cs
@@ -55,6 +55,8 @@ public static class ErrorOrFactory
     /// <typeparam name="TValue">The type of the value.</typeparam>
     /// <param name="errors">List of errors.</param>
     /// <returns>An instance of <see cref="ErrorOr{TValue}"/> containing provided list of errors.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="errors" /> is an empty list.</exception>
     public static ErrorOr<TValue> From<TValue>(List<Error> errors)
     {
         return errors;
@@ -66,6 +68,8 @@ public static class ErrorOrFactory
     /// <typeparam name="TValue">The type of the value.</typeparam>
     /// <param name="errors">List of errors.</param>
     /// <returns>An awaitable instance of <see cref="ErrorOr{TValue}"/> containing provided list of errors.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="errors" /> is an empty list.</exception>
     public static Task<ErrorOr<TValue>> FromAsync<TValue>(List<Error> errors)
     {
         return Task.FromResult(From<TValue>(errors));
@@ -77,6 +81,8 @@ public static class ErrorOrFactory
     /// <typeparam name="TValue">The type of the value.</typeparam>
     /// <param name="errors">Enumeration of errors.</param>
     /// <returns>An instance of <see cref="ErrorOr{TValue}"/> containing provided enumeration of errors.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="errors" /> is an empty enumerable.</exception>
     public static ErrorOr<TValue> From<TValue>(IEnumerable<Error> errors)
     {
         return errors.ToList();
@@ -88,6 +94,8 @@ public static class ErrorOrFactory
     /// <typeparam name="TValue">The type of the value.</typeparam>
     /// <param name="errors">Enumeration of errors.</param>
     /// <returns>An awaitable instance of <see cref="ErrorOr{TValue}"/> containing provided enumeration of errors.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="errors" /> is an empty enumerable.</exception>
     public static Task<ErrorOr<TValue>> FromAsync<TValue>(IEnumerable<Error> errors)
     {
         return Task.FromResult(From<TValue>(errors));

--- a/src/ErrorOr/ErrorOrFactory.cs
+++ b/src/ErrorOr/ErrorOrFactory.cs
@@ -61,6 +61,17 @@ public static class ErrorOrFactory
     }
 
     /// <summary>
+    /// Creates an awaitable <see cref="ErrorOr{TValue}"/> from a list of errors.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <param name="errors">List of errors.</param>
+    /// <returns>An awaitable instance of <see cref="ErrorOr{TValue}"/> containing provided list of errors.</returns>
+    public static Task<ErrorOr<TValue>> FromAsync<TValue>(List<Error> errors)
+    {
+        return Task.FromResult(From<TValue>(errors));
+    }
+
+    /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> from an enumeration of errors.
     /// </summary>
     /// <typeparam name="TValue">The type of the value.</typeparam>

--- a/src/ErrorOr/ErrorOrFactory.cs
+++ b/src/ErrorOr/ErrorOrFactory.cs
@@ -39,6 +39,17 @@ public static class ErrorOrFactory
     }
 
     /// <summary>
+    /// Creates a new awaitable instance of <see cref="ErrorOr{TValue}"/> from single error.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <param name="error">Single error instance to wrap.</param>
+    /// <returns>An awaitable instance of <see cref="ErrorOr{TValue}"/> containing the provided error.</returns>
+    public static Task<ErrorOr<TValue>> FromAsync<TValue>(Error error)
+    {
+        return Task.FromResult(From<TValue>(error));
+    }
+
+    /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> from a list of errors.
     /// </summary>
     /// <typeparam name="TValue">The type of the value.</typeparam>

--- a/src/ErrorOr/ErrorOrFactory.cs
+++ b/src/ErrorOr/ErrorOrFactory.cs
@@ -17,6 +17,17 @@ public static class ErrorOrFactory
     }
 
     /// <summary>
+    /// Creates a new awaitable instance of <see cref="ErrorOr{TValue}"/> from value.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <param name="value">The value to wrap.</param>
+    /// <returns>An awaitable instance of <see cref="ErrorOr{TValue}"/> containing provided value.</returns>
+    public static Task<ErrorOr<TValue>> FromAsync<TValue>(TValue value)
+    {
+        return Task.FromResult(From(value));
+    }
+
+    /// <summary>
     /// Creates a new instance of <see cref="ErrorOr{TValue}"/> from single error.
     /// </summary>
     /// <typeparam name="TValue">The type of the value.</typeparam>

--- a/src/ErrorOr/ErrorOrFactory.cs
+++ b/src/ErrorOr/ErrorOrFactory.cs
@@ -81,4 +81,15 @@ public static class ErrorOrFactory
     {
         return errors.ToList();
     }
+
+    /// <summary>
+    /// Creates an awaitable <see cref="ErrorOr{TValue}"/> from an enumeration of errors.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <param name="errors">Enumeration of errors.</param>
+    /// <returns>An awaitable instance of <see cref="ErrorOr{TValue}"/> containing provided enumeration of errors.</returns>
+    public static Task<ErrorOr<TValue>> FromAsync<TValue>(IEnumerable<Error> errors)
+    {
+        return Task.FromResult(From<TValue>(errors));
+    }
 }

--- a/src/ErrorOr/ErrorOrFactory.cs
+++ b/src/ErrorOr/ErrorOrFactory.cs
@@ -6,7 +6,7 @@ namespace ErrorOr;
 public static class ErrorOrFactory
 {
     /// <summary>
-    /// Creates a new instance of <see cref="ErrorOr{TValue}"/> with a value.
+    /// Creates a new instance of <see cref="ErrorOr{TValue}"/> from a value.
     /// </summary>
     /// <typeparam name="TValue">The type of the value.</typeparam>
     /// <param name="value">The value to wrap.</param>
@@ -61,7 +61,7 @@ public static class ErrorOrFactory
     }
 
     /// <summary>
-    /// Creates an awaitable <see cref="ErrorOr{TValue}"/> from a list of errors.
+    /// Creates an awaitable instance of<see cref="ErrorOr{TValue}"/> from a list of errors.
     /// </summary>
     /// <typeparam name="TValue">The type of the value.</typeparam>
     /// <param name="errors">List of errors.</param>
@@ -83,7 +83,7 @@ public static class ErrorOrFactory
     }
 
     /// <summary>
-    /// Creates an awaitable <see cref="ErrorOr{TValue}"/> from an enumeration of errors.
+    /// Creates an awaitable instance of<see cref="ErrorOr{TValue}"/> from an enumeration of errors.
     /// </summary>
     /// <typeparam name="TValue">The type of the value.</typeparam>
     /// <param name="errors">Enumeration of errors.</param>

--- a/src/ErrorOr/ErrorOrFactory.cs
+++ b/src/ErrorOr/ErrorOrFactory.cs
@@ -55,8 +55,6 @@ public static class ErrorOrFactory
     /// <typeparam name="TValue">The type of the value.</typeparam>
     /// <param name="errors">List of errors.</param>
     /// <returns>An instance of <see cref="ErrorOr{TValue}"/> containing provided list of errors.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="errors" /> is an empty list.</exception>
     public static ErrorOr<TValue> From<TValue>(List<Error> errors)
     {
         return errors;
@@ -68,8 +66,6 @@ public static class ErrorOrFactory
     /// <typeparam name="TValue">The type of the value.</typeparam>
     /// <param name="errors">List of errors.</param>
     /// <returns>An awaitable instance of <see cref="ErrorOr{TValue}"/> containing provided list of errors.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="errors" /> is an empty list.</exception>
     public static Task<ErrorOr<TValue>> FromAsync<TValue>(List<Error> errors)
     {
         return Task.FromResult(From<TValue>(errors));
@@ -81,8 +77,6 @@ public static class ErrorOrFactory
     /// <typeparam name="TValue">The type of the value.</typeparam>
     /// <param name="errors">Enumeration of errors.</param>
     /// <returns>An instance of <see cref="ErrorOr{TValue}"/> containing provided enumeration of errors.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="errors" /> is an empty enumerable.</exception>
     public static ErrorOr<TValue> From<TValue>(IEnumerable<Error> errors)
     {
         return errors.ToList();
@@ -94,8 +88,6 @@ public static class ErrorOrFactory
     /// <typeparam name="TValue">The type of the value.</typeparam>
     /// <param name="errors">Enumeration of errors.</param>
     /// <returns>An awaitable instance of <see cref="ErrorOr{TValue}"/> containing provided enumeration of errors.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="errors" /> is an empty enumerable.</exception>
     public static Task<ErrorOr<TValue>> FromAsync<TValue>(IEnumerable<Error> errors)
     {
         return Task.FromResult(From<TValue>(errors));

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -140,6 +140,20 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
+    public async Task CreateFromAsyncErrorList_UsingFactory_WhenAccessingErrors_ShouldReturnErrorList()
+    {
+        // Arrange
+        var error = Error.Validation("User.Name", "Name is too short");
+
+        // Act
+        ErrorOr<Person> errorOrPerson = await ErrorOrFactory.FromAsync<Person>([error]);
+
+        // Assert
+        errorOrPerson.IsError.Should().BeTrue();
+        errorOrPerson.Errors.Should().ContainSingle().Which.Should().Be(error);
+    }
+
+    [Fact]
     [Obsolete]
     public void CreateFromErrorList_WhenAccessingErrors_ShouldReturnErrorList()
     {

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -218,6 +218,16 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
+    public async Task CreateFromAsyncSingleError_UsingFactory_ShouldBeError()
+    {
+        // Act
+        ErrorOr<Person> errorOrPerson = await ErrorOrFactory.FromAsync<Person>(Error.Validation("User.Name", "Name is too short"));
+
+        // Assert
+        errorOrPerson.IsError.Should().BeTrue();
+    }
+
+    [Fact]
     public void CreateFromArrayOfErrors_UsingFactory_ShouldBeError()
     {
         // Arrange

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -258,6 +258,22 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
+    public async Task CreateFromAsyncArrayOfErrors_UsingFactory_ShouldBeError()
+    {
+        // Arrange
+        Error[] errors = [
+            Error.Validation("User.Name", "Name is too short"),
+            Error.Forbidden("User.Forbidden", "You are not allowed to create user")
+        ];
+
+        // Act
+        ErrorOr<Person> errorOrPerson = await ErrorOrFactory.FromAsync<Person>(errors);
+
+        // Assert
+        errorOrPerson.IsError.Should().BeTrue();
+    }
+
+    [Fact]
     public void ImplicitCastResult_WhenAccessingResult_ShouldReturnValue()
     {
         // Arrange

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -112,6 +112,20 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
+    public async Task CreateFromAsyncValue_WhenAccessingValue_ShouldReturnValue()
+    {
+        // Arrange
+        IEnumerable<string> value = ["value"];
+
+        // Act
+        ErrorOr<IEnumerable<string>> errorOrPerson = await ErrorOrFactory.FromAsync(value);
+
+        // Assert
+        errorOrPerson.IsError.Should().BeFalse();
+        errorOrPerson.Value.Should().BeSameAs(value);
+    }
+
+    [Fact]
     public void CreateFromErrorList_UsingFactory_WhenAccessingErrors_ShouldReturnErrorList()
     {
         // Arrange

--- a/tests/ErrorOr/ErrorOr.ToErrorOrTests.cs
+++ b/tests/ErrorOr/ErrorOr.ToErrorOrTests.cs
@@ -49,6 +49,21 @@ public class ToErrorOrTests
     }
 
     [Fact]
+    public async Task ErrorToErrorOrAsync_WhenAccessingFirstError_ShouldReturnSameError()
+    {
+        // Arrange
+        Error error = Error.Unauthorized();
+        Task<Error> task = Task.FromResult(error);
+
+        // Act
+        ErrorOr<int> result = await task.ToErrorOrAsync<int>();
+
+        // Assert
+        result.IsError.Should().BeTrue();
+        result.FirstError.Should().Be(error);
+    }
+
+    [Fact]
     public void ListOfErrorsToErrorOr_WhenAccessingErrors_ShouldReturnSameErrors()
     {
         // Arrange
@@ -63,12 +78,60 @@ public class ToErrorOrTests
     }
 
     [Fact]
-    public void ArrayOfErrorsToErrorOr_WhenAccessingErrors_ShouldReturnSimilarErrors()
+    public async Task ListOfErrorsToErrorOrAsync_WhenAccessingErrors_ShouldReturnSameErrors()
     {
+        // Arrange
+        List<Error> errors = [Error.Unauthorized(), Error.Validation()];
+        Task<List<Error>> task = Task.FromResult(errors);
+
+        // Act
+        ErrorOr<int> result = await task.ToErrorOrAsync<int>();
+
+        // Assert
+        result.IsError.Should().BeTrue();
+        result.Errors.Should().BeEquivalentTo(errors);
+    }
+
+    [Fact]
+    public void EnumerableOfErrorsToErrorOr_WhenAccessingErrors_ShouldReturnSimilarErrors()
+    {
+        // Arrange
         Error[] errors = [Error.Unauthorized(), Error.Validation()];
 
+        // Act
         ErrorOr<int> result = errors.ToErrorOr<int>();
 
+        // Assert
+        result.IsError.Should().BeTrue();
+        result.Errors.Should().Equal(errors);
+    }
+
+    [Fact]
+    public async Task ArrayOfErrorsToErrorOrAsync_WhenAccessingErrors_ShouldReturnSimilarErrors()
+    {
+        // Arrange
+        Error[] errors = [Error.Unauthorized(), Error.Validation()];
+        Task<Error[]> task = Task.FromResult(errors);
+
+        // Act
+        ErrorOr<int> result = await task.ToErrorOrAsync<int>();
+
+        // Assert
+        result.IsError.Should().BeTrue();
+        result.Errors.Should().Equal(errors);
+    }
+
+    [Fact]
+    public async Task EnumerableOfErrorsToErrorOrAsync_WhenAccessingErrors_ShouldReturnSimilarErrors()
+    {
+        // Arrange
+        Error[] errors = [Error.Unauthorized(), Error.Validation()];
+        Task<IEnumerable<Error>> task = Task.FromResult((IEnumerable<Error>)errors);
+
+        // Act
+        ErrorOr<int> result = await task.ToErrorOrAsync<int>();
+
+        // Assert
         result.IsError.Should().BeTrue();
         result.Errors.Should().Equal(errors);
     }

--- a/tests/ErrorOr/TestUtils.cs
+++ b/tests/ErrorOr/TestUtils.cs
@@ -8,7 +8,7 @@ public static class Convert
 
     public static ErrorOr<int> ToInt(string str) => int.Parse(str);
 
-    public static Task<ErrorOr<int>> ToIntAsync(string str) => Task.FromResult(ErrorOrFactory.From(int.Parse(str)));
+    public static Task<ErrorOr<int>> ToIntAsync(string str) => ErrorOrFactory.FromAsync(int.Parse(str));
 
-    public static Task<ErrorOr<string>> ToStringAsync(int num) => Task.FromResult(ErrorOrFactory.From(num.ToString()));
+    public static Task<ErrorOr<string>> ToStringAsync(int num) => ErrorOrFactory.FromAsync(num.ToString());
 }


### PR DESCRIPTION
Added support for `FromAsync` methods:

```cs
public async Tak<ErrorOr<int>> GetValueAsync()
{
    return await ErrorOrFactory.FromAsync(5);
}
```
```cs
public async Tak<ErrorOr<int>> SingleErrorToErrorOrAsync()
{
    return await ErrorOrFactory.FromAsync<int>(Error.Unexpected());
}
```
```cs
public async Tak<ErrorOr<int>> MultipleErrorsToErrorOrAsync()
{
    return await ErrorOrFactory.FromAsync([
        Error.Validation(description: "Invalid Name"),
        Error.Validation(description: "Invalid Last Name")
    ]);
}
```

Added support for `ToErrorOrAsync` methods from errors:

```cs
Task<Error> errorTask = Task.FromResult(Error.Validation());
ErrorOr<int> result = errorTask.ToErrorOrAsync<int>();
```
```cs
List<Error> errors = [Error.Unauthorized(), Error.Validation()];
Task<List<Error>> errorsTask = Task.FromResult(errors);
ErrorOr<int> result = await errorsTask.ToErrorOrAsync<int>();
```