### PR TITLE
Optimization: extensive null checks

### DIFF
--- a/src/ErrorOr/ErrorOr.ImplicitConverters.cs
+++ b/src/ErrorOr/ErrorOr.ImplicitConverters.cs
@@ -25,21 +25,16 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// <exception cref="ArgumentException">Thrown when <paramref name="errors" /> is an empty list.</exception>
     public static implicit operator ErrorOr<TValue>(List<Error> errors)
     {
-        return new ErrorOr<TValue>(errors);
+        return errors is null ? throw new ArgumentNullException(nameof(errors)) : new ErrorOr<TValue>(errors);
     }
 
     /// <summary>
-    /// Creates an <see cref="ErrorOr{TValue}"/> from a list of errors.
+    /// Creates an <see cref="ErrorOr{TValue}"/> from an array of errors.
     /// </summary>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="errors" /> is an empty array.</exception>
     public static implicit operator ErrorOr<TValue>(Error[] errors)
     {
-        if (errors is null)
-        {
-            throw new ArgumentNullException(nameof(errors));
-        }
-
-        return new ErrorOr<TValue>([.. errors]);
+        return errors is null ? throw new ArgumentNullException(nameof(errors)) : new ErrorOr<TValue>([.. errors]);
     }
 }

--- a/src/ErrorOr/ErrorOr.cs
+++ b/src/ErrorOr/ErrorOr.cs
@@ -32,7 +32,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
             throw new ArgumentNullException(nameof(errors));
         }
 
-        if (errors is null || errors.Count == 0)
+        if (errors.Count == 0)
         {
             throw new ArgumentException("Cannot create an ErrorOr<TValue> from an empty collection of errors. Provide at least one error.", nameof(errors));
         }

--- a/src/ErrorOr/ErrorOr.cs
+++ b/src/ErrorOr/ErrorOr.cs
@@ -20,6 +20,16 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
         throw new InvalidOperationException("Default construction of ErrorOr<TValue> is invalid. Please use provided factory methods to instantiate.");
     }
 
+    private ErrorOr(TValue value)
+    {
+        if (value is null)
+        {
+            throw new ArgumentNullException(nameof(value));
+        }
+
+        _value = value;
+    }
+
     private ErrorOr(Error error)
     {
         _errors = [error];
@@ -33,16 +43,6 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
         }
 
         _errors = errors;
-    }
-
-    private ErrorOr(TValue value)
-    {
-        if (value is null)
-        {
-            throw new ArgumentNullException(nameof(value));
-        }
-
-        _value = value;
     }
 
     /// <summary>

--- a/src/ErrorOr/ErrorOr.cs
+++ b/src/ErrorOr/ErrorOr.cs
@@ -27,11 +27,6 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
 
     private ErrorOr(List<Error> errors)
     {
-        if (errors is null)
-        {
-            throw new ArgumentNullException(nameof(errors));
-        }
-
         if (errors.Count == 0)
         {
             throw new ArgumentException("Cannot create an ErrorOr<TValue> from an empty collection of errors. Provide at least one error.", nameof(errors));


### PR DESCRIPTION
Collection constructor is called from two places: implicit conversion from list of error and from array of errors. I have noticed that implicit conversion from array of errors has its own null check so effectively it is done twice. I have added null check in implicit conversion from list of errors and removed one from constructor. Additionally I have fixed inaccurate array converter description and moved Value constructor at the top of constructor block.

Contains #128 