### PR TITLE
Feature: exposing weakly typed value in interface

### DIFF
--- a/src/ErrorOr/ErrorOr.cs
+++ b/src/ErrorOr/ErrorOr.cs
@@ -71,6 +71,9 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// <inheritdoc/>
     public IEnumerator<Error> GetEnumerator() => _errors!.GetEnumerator();
 
+    /// <inheritdoc/>
+    object? IErrorOr.Value => _value;
+
     /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> from a list of errors.
     /// </summary>

--- a/src/ErrorOr/ErrorOr.cs
+++ b/src/ErrorOr/ErrorOr.cs
@@ -69,10 +69,10 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     }
 
     /// <inheritdoc/>
-    public IEnumerator<Error> GetEnumerator() => _errors!.GetEnumerator();
+    object? IErrorOr.Value => _value;
 
     /// <inheritdoc/>
-    object? IErrorOr.Value => _value;
+    public IEnumerator<Error> GetEnumerator() => _errors!.GetEnumerator();
 
     /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> from a list of errors.

--- a/src/ErrorOr/IErrorOr.cs
+++ b/src/ErrorOr/IErrorOr.cs
@@ -2,24 +2,33 @@ using System.Runtime.CompilerServices;
 
 namespace ErrorOr;
 
+/// <summary>
+/// Strongly-typed interface for <see cref="ErrorOr{TValue}"/> object.
+/// </summary>
+/// <typeparam name="TValue">The type of the underlying <see cref="ErrorOr{TValue}.Value"/>.</typeparam>
 [CollectionBuilder(typeof(CollectionExpression), nameof(CollectionExpression.CreateIErrorOrValue))]
 public interface IErrorOr<out TValue> : IErrorOr
 {
     /// <summary>
-    /// Gets the value.
+    /// Gets strongly-typed the value.
     /// </summary>
-    TValue Value { get; }
+    new TValue Value { get; }
 }
 
 /// <summary>
-/// Type-less interface for the <see cref="ErrorOr"/> object.
+/// Weakly-typed interface for the <see cref="ErrorOr{TValue}"/> object.
 /// </summary>
 /// <remarks>
-/// This interface is intended for use when the underlying type of the <see cref="ErrorOr"/> object is unknown.
+/// This interface is intended for use when the underlying type of the <see cref="ErrorOr{TValue}"/> object is unknown.
 /// </remarks>
 [CollectionBuilder(typeof(CollectionExpression), nameof(CollectionExpression.CreateIErrorOr))]
 public interface IErrorOr : IRecordable
 {
+    /// <summary>
+    /// Gets weakly-typed value.
+    /// </summary>
+    object? Value { get; }
+
     /// <summary>
     /// Gets the list of errors.
     /// </summary>

--- a/src/ErrorOr/IErrorOr.cs
+++ b/src/ErrorOr/IErrorOr.cs
@@ -10,7 +10,7 @@ namespace ErrorOr;
 public interface IErrorOr<out TValue> : IErrorOr
 {
     /// <summary>
-    /// Gets strongly-typed the value.
+    /// Gets strongly-typed value.
     /// </summary>
     new TValue Value { get; }
 }

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -84,6 +84,23 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
+    public void CreateFromValue_WhenAccessingValue_ViaStronglyTypedInterface_ShouldReturnValue()
+    {
+        // Arrange
+        IEnumerable<string> value = ["value"];
+
+        // Act
+#pragma warning disable CA1859 // Use concrete types when possible for improved performance
+        IErrorOr<IEnumerable<string>> errorOrPerson = ErrorOrFactory.From(value);
+#pragma warning restore CA1859 // Use concrete types when possible for improved performance
+
+        // Assert
+        errorOrPerson.IsError.Should().BeFalse();
+        errorOrPerson.Value.Should().BeSameAs(value);
+    }
+
+    [Fact]
+    public void CreateFromValue_WhenAccessingErrors_ShouldThrow()
     public void CreateFromValue_WhenAccessingErrorsOrEmptyList_ShouldReturnEmptyList()
     {
         // Arrange

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -100,6 +100,22 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
+    public void CreateFromValue_WhenAccessingValue_ViaWeaklyTypedInterface_ShouldReturnValue()
+    {
+        // Arrange
+        IEnumerable<string> value = ["value"];
+
+        // Act
+#pragma warning disable CA1859 // Use concrete types when possible for improved performance
+        IErrorOr errorOrPerson = ErrorOrFactory.From(value);
+#pragma warning restore CA1859 // Use concrete types when possible for improved performance
+
+        // Assert
+        errorOrPerson.IsError.Should().BeFalse();
+        errorOrPerson.Value.Should().BeSameAs(value);
+    }
+
+    [Fact]
     public void CreateFromValue_WhenAccessingErrors_ShouldThrow()
     public void CreateFromValue_WhenAccessingErrorsOrEmptyList_ShouldReturnEmptyList()
     {

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -38,6 +38,22 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
+    public void CreateFromValue_WhenAccessingValue_ViaWeaklyTypedInterface_ShouldReturnValue()
+    {
+        // Arrange
+        IEnumerable<string> value = ["value"];
+
+        // Act
+#pragma warning disable CA1859 // Use concrete types when possible for improved performance
+        IErrorOr errorOrValue = ErrorOrFactory.From(value);
+#pragma warning restore CA1859 // Use concrete types when possible for improved performance
+
+        // Assert
+        errorOrValue.IsError.Should().BeFalse();
+        errorOrValue.Value.Should().BeSameAs(value);
+    }
+
+    [Fact]
     public void CreateFromValue_WhenAccessingValue_ViaIRecordable_ShouldReturnJson()
     {
         // Arrange
@@ -83,39 +99,6 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
-    public void CreateFromValue_WhenAccessingValue_ViaStronglyTypedInterface_ShouldReturnValue()
-    {
-        // Arrange
-        IEnumerable<string> value = ["value"];
-
-        // Act
-#pragma warning disable CA1859 // Use concrete types when possible for improved performance
-        IErrorOr<IEnumerable<string>> errorOrValue = ErrorOrFactory.From(value);
-#pragma warning restore CA1859 // Use concrete types when possible for improved performance
-
-        // Assert
-        errorOrValue.IsError.Should().BeFalse();
-        errorOrValue.Value.Should().BeSameAs(value);
-    }
-
-    [Fact]
-    public void CreateFromValue_WhenAccessingValue_ViaWeaklyTypedInterface_ShouldReturnValue()
-    {
-        // Arrange
-        IEnumerable<string> value = ["value"];
-
-        // Act
-#pragma warning disable CA1859 // Use concrete types when possible for improved performance
-        IErrorOr errorOrValue = ErrorOrFactory.From(value);
-#pragma warning restore CA1859 // Use concrete types when possible for improved performance
-
-        // Assert
-        errorOrValue.IsError.Should().BeFalse();
-        errorOrValue.Value.Should().BeSameAs(value);
-    }
-
-    [Fact]
-    public void CreateFromValue_WhenAccessingErrors_ShouldThrow()
     public void CreateFromValue_WhenAccessingErrorsOrEmptyList_ShouldReturnEmptyList()
     {
         // Arrange

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -1,7 +1,6 @@
 namespace Tests;
 
 using ErrorOr;
-
 using FluentAssertions;
 
 public class ErrorOrInstantiationTests
@@ -91,12 +90,12 @@ public class ErrorOrInstantiationTests
 
         // Act
 #pragma warning disable CA1859 // Use concrete types when possible for improved performance
-        IErrorOr<IEnumerable<string>> errorOrPerson = ErrorOrFactory.From(value);
+        IErrorOr<IEnumerable<string>> errorOrValue = ErrorOrFactory.From(value);
 #pragma warning restore CA1859 // Use concrete types when possible for improved performance
 
         // Assert
-        errorOrPerson.IsError.Should().BeFalse();
-        errorOrPerson.Value.Should().BeSameAs(value);
+        errorOrValue.IsError.Should().BeFalse();
+        errorOrValue.Value.Should().BeSameAs(value);
     }
 
     [Fact]
@@ -107,12 +106,12 @@ public class ErrorOrInstantiationTests
 
         // Act
 #pragma warning disable CA1859 // Use concrete types when possible for improved performance
-        IErrorOr errorOrPerson = ErrorOrFactory.From(value);
+        IErrorOr errorOrValue = ErrorOrFactory.From(value);
 #pragma warning restore CA1859 // Use concrete types when possible for improved performance
 
         // Assert
-        errorOrPerson.IsError.Should().BeFalse();
-        errorOrPerson.Value.Should().BeSameAs(value);
+        errorOrValue.IsError.Should().BeFalse();
+        errorOrValue.Value.Should().BeSameAs(value);
     }
 
     [Fact]


### PR DESCRIPTION
I have added weakly-typed `Value` property to `IErrorOr` interface as described in #121.

Example:
```cs
 IErrorOr errorOrPerson = ErrorOrFactory.From(person);
 if (!errorOrPerson.IsError)
 {
     Console.WriteLine(errorOrPerson.Value);
 }
```