### PR TITLE
Bugfix: FailIf samples with error factory lacks lambda parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ return await _userRepository.GetByIdAsync(id)
 ```cs
 ErrorOr<string> foo = await "2".ToErrorOr()
     .Then(int.Parse) // 2
-    .FailIf(val => val > 2, Error.Validation(description: $"{val} is too big") // 2
+    .FailIf(val => val > 2, val => Error.Validation(description: $"{val} is too big") // 2
     .ThenDoAsync(Task.Delay) // Sleep for 2 milliseconds
     .ThenDo(val => Console.WriteLine($"Finished waiting {val} milliseconds.")) // Finished waiting 2 milliseconds.
     .ThenAsync(val => Task.FromResult(val * 2)) // 4
@@ -214,7 +214,7 @@ ErrorOr<string> foo = await "2".ToErrorOr()
 ```cs
 ErrorOr<string> foo = await "5".ToErrorOr()
     .Then(int.Parse) // 5
-    .FailIf(val => val > 2, Error.Validation(description: $"{val} is too big") // Error.Validation()
+    .FailIf(val => val > 2, val => Error.Validation(description: $"{val} is too big") // Error.Validation()
     .ThenDoAsync(Task.Delay) // Error.Validation()
     .ThenDo(val => Console.WriteLine($"Finished waiting {val} milliseconds.")) // Error.Validation()
     .ThenAsync(val => Task.FromResult(val * 2)) // Error.Validation()
@@ -526,7 +526,7 @@ ErrorOr<string> foo = await result
 
 ```cs
 ErrorOr<int> foo = result
-    .FailIf(val => val > 2, Error.Validation(description: $"{val} is too big"));
+    .FailIf(val => val > 2, val => Error.Validation(description: $"{val} is too big"));
 ```
 
 Once an error is returned, the chain will break and the error will be returned.
@@ -534,7 +534,7 @@ Once an error is returned, the chain will break and the error will be returned.
 ```cs
 var result = "2".ToErrorOr()
     .Then(int.Parse) // 2
-    .FailIf(val => val > 1, Error.Validation(description: $"{val} is too big") // validation error
+    .FailIf(val => val > 1, val => Error.Validation(description: $"{val} is too big") // validation error
     .Then(num => num * 2) // this function will not be invoked
     .Then(num => num * 2) // this function will not be invoked
 ```
@@ -574,7 +574,7 @@ You can mix `Then`, `FailIf`, `Else`, `Switch` and `Match` methods together.
 ```cs
 ErrorOr<string> foo = await result
     .ThenDoAsync(val => Task.Delay(val))
-    .FailIf(val => val > 2, Error.Validation(description: $"{val} is too big"))
+    .FailIf(val => val > 2, val => Error.Validation(description: $"{val} is too big"))
     .ThenDo(val => Console.WriteLine($"Finished waiting {val} seconds."))
     .ThenAsync(val => Task.FromResult(val * 2))
     .Then(val => $"The result is {val}")


### PR DESCRIPTION
In [README.md](https://github.com/amantinband/error-or?tab=readme-ov-file#failif) there are samples of `FailIf` method with error factory where no lambda parameter are present. Here are fixes.

Example:
```csharp
ErrorOr<int> foo = result
    .FailIf(val => val > 2, val => Error.Validation(description: $"{val} is too big"));
```

Fixes: #138 