### PR TITLE
Fix issue_32. Added Extensions for AspNetCore.

### DIFF
--- a/ErrorOr.sln
+++ b/ErrorOr.sln
@@ -1,19 +1,18 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30114.105
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.35122.118
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ErrorOr", "src\ErrorOr.csproj", "{19633D81-11FE-4C55-AA8D-452D20EEEF98}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ErrorOr", "src\ErrorOr.csproj", "{19633D81-11FE-4C55-AA8D-452D20EEEF98}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "tests", "tests\Tests.csproj", "{0E84EC69-4E4C-4195-907D-06C96D0140A6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tests", "tests\Tests.csproj", "{0E84EC69-4E4C-4195-907D-06C96D0140A6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Extensions", "Extensions\Extensions.csproj", "{4CB3A671-D36D-439F-B276-0F555B77304F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{19633D81-11FE-4C55-AA8D-452D20EEEF98}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -24,5 +23,15 @@ Global
 		{0E84EC69-4E4C-4195-907D-06C96D0140A6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0E84EC69-4E4C-4195-907D-06C96D0140A6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0E84EC69-4E4C-4195-907D-06C96D0140A6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4CB3A671-D36D-439F-B276-0F555B77304F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4CB3A671-D36D-439F-B276-0F555B77304F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4CB3A671-D36D-439F-B276-0F555B77304F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4CB3A671-D36D-439F-B276-0F555B77304F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {EF0E71AC-0E4A-40A3-8BB1-A4AF1EFEC4EA}
 	EndGlobalSection
 EndGlobal

--- a/Extensions/AspNetCore/ControllerBaseExtensions.cs
+++ b/Extensions/AspNetCore/ControllerBaseExtensions.cs
@@ -1,0 +1,159 @@
+using ErrorOr;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Extensions.AspNetCore
+{
+    /// <summary>
+    /// Provides extension methods for ASP.NET Core <see cref="ControllerBase"/> to convert
+    /// <see cref="ErrorOr{T}"/> results into standardized <see cref="ActionResult"/> or <see cref="IActionResult"/>.
+    /// </summary>
+    public static class ControllerBaseExtensions
+    {
+        /// <summary>
+        /// Converts an <see cref="ErrorOr{T}"/> to an <see cref="ActionResult{T}"/>.
+        /// If the result contains an error, it converts it to a standardized <see cref="ProblemDetails"/> response.
+        /// </summary>
+        /// <typeparam name="T">Type of the success value.</typeparam>
+        /// <param name="controller">The controller instance calling this method.</param>
+        /// <param name="result">The <see cref="ErrorOr{T}"/> result to convert.</param>
+        /// <returns>An <see cref="ActionResult{T}"/> containing either the value or the problem details.</returns>
+        public static ActionResult<T> ConvertToActionResult<T>(
+            this ControllerBase controller,
+            ErrorOr<T> result) =>
+            result.MatchFirst<ActionResult<T>>(
+                value => controller.Ok(value),
+                error => ConvertError(controller, error));
+
+        /// <summary>
+        /// Converts an <see cref="ErrorOr{T}"/> to an <see cref="ActionResult"/> without returning data.
+        /// If the result contains an error, it converts it to a standardized <see cref="ProblemDetails"/> response.
+        /// </summary>
+        /// <typeparam name="T">Type of the success value.</typeparam>
+        /// <param name="controller">The controller instance calling this method.</param>
+        /// <param name="result">The <see cref="ErrorOr{T}"/> result to convert.</param>
+        /// <returns>An <see cref="ActionResult"/> representing success or a problem.</returns>
+        public static ActionResult ConvertToActionResultWithoutData<T>(
+            this ControllerBase controller,
+            ErrorOr<T> result) =>
+            result.MatchFirst(
+                _ => controller.Ok(),
+                error => ConvertError(controller, error));
+
+        /// <summary>
+        /// Converts an <see cref="ErrorOr{TIn}"/> to <see cref="ActionResult{TOut}"/> using a mapping function.
+        /// </summary>
+        /// <typeparam name="TIn">Input type of the result.</typeparam>
+        /// <typeparam name="TOut">Output type after mapping.</typeparam>
+        /// <param name="controller">The controller instance calling this method.</param>
+        /// <param name="result">The <see cref="ErrorOr{TIn}"/> result to convert.</param>
+        /// <param name="map">Function to convert <typeparamref name="TIn"/> to <typeparamref name="TOut"/>.</param>
+        /// <returns>An <see cref="ActionResult{TOut}"/> containing either the mapped value or problem details.</returns>
+        public static ActionResult<TOut> ConvertToActionResult<TIn, TOut>(
+            this ControllerBase controller,
+            ErrorOr<TIn> result,
+            Func<TIn, TOut> map) =>
+            result.MatchFirst(
+                value => controller.Ok(map(value)),
+                error => ConvertError(controller, error));
+
+        /// <summary>
+        /// Converts an <see cref="ErrorOr{TIn}"/> asynchronously to <see cref="ActionResult{TOut}"/> using a mapping function.
+        /// </summary>
+        /// <typeparam name="TIn">Input type of the result.</typeparam>
+        /// <typeparam name="TOut">Output type after mapping.</typeparam>
+        /// <param name="controller">The controller instance calling this method.</param>
+        /// <param name="result">The <see cref="ErrorOr{TIn}"/> result to convert.</param>
+        /// <param name="map">Asynchronous function to convert <typeparamref name="TIn"/> to <see cref="ActionResult{TOut}"/>.</param>
+        /// <returns>A task producing an <see cref="ActionResult{TOut}"/> containing either the mapped value or problem details.</returns>
+        public static async Task<ActionResult<TOut>> ConvertToActionResultAsync<TIn, TOut>(
+            this ControllerBase controller,
+            ErrorOr<TIn> result,
+            Func<TIn, Task<ActionResult<TOut>>> map)
+        {
+            if (result.IsError)
+            {
+                return ConvertError(controller, result.FirstError);
+            }
+
+            return await map(result.Value);
+        }
+
+        /// <summary>
+        /// Converts an <see cref="ErrorOr{TIn}"/> to <see cref="IActionResult"/> using a mapping function.
+        /// </summary>
+        /// <typeparam name="TIn">Input type of the result.</typeparam>
+        /// <typeparam name="TOut">Output type after mapping.</typeparam>
+        /// <param name="controller">The controller instance calling this method.</param>
+        /// <param name="result">The <see cref="ErrorOr{TIn}"/> result to convert.</param>
+        /// <param name="map">Function to convert <typeparamref name="TIn"/> to <typeparamref name="TOut"/>.</param>
+        /// <returns>An <see cref="IActionResult"/> containing either the mapped value or problem details.</returns>
+        public static IActionResult ConvertToIActionResult<TIn, TOut>(
+            this ControllerBase controller,
+            ErrorOr<TIn> result,
+            Func<TIn, TOut> map) =>
+            result.MatchFirst(
+                value => controller.Ok(map(value)),
+                error => ConvertError(controller, error));
+
+        /// <summary>
+        /// Converts an <see cref="ErrorOr{TIn}"/> asynchronously to <see cref="IActionResult"/> using a mapping function.
+        /// </summary>
+        /// <typeparam name="TIn">Input type of the result.</typeparam>
+        /// <typeparam name="TOut">Output type after mapping.</typeparam>
+        /// <param name="controller">The controller instance calling this method.</param>
+        /// <param name="result">The <see cref="ErrorOr{TIn}"/> result to convert.</param>
+        /// <param name="map">Asynchronous function to convert <typeparamref name="TIn"/> to <typeparamref name="TOut"/>.</param>
+        /// <returns>A task producing an <see cref="IActionResult"/> containing either the mapped value or problem details.</returns>
+        public static async Task<IActionResult> ConvertToIActionResultAsync<TIn, TOut>(
+            this ControllerBase controller,
+            ErrorOr<TIn> result,
+            Func<TIn, Task<TOut>> map)
+        {
+            if (result.IsError)
+            {
+                return ConvertError(controller, result.FirstError);
+            }
+
+            var output = await map(result.Value);
+            return controller.Ok(output);
+        }
+
+        /// <summary>
+        /// Converts an <see cref="Error"/> into a standardized <see cref="ProblemDetails"/> response
+        /// following RFC 7807 for HTTP APIs.
+        /// </summary>
+        /// <param name="controller">The controller instance calling this method.</param>
+        /// <param name="error">The <see cref="Error"/> to convert.</param>
+        /// <returns>An <see cref="ActionResult"/> containing <see cref="ProblemDetails"/>.</returns>
+        public static ActionResult ConvertError(this ControllerBase controller, Error error)
+        {
+            var statusCode = error.Type switch
+            {
+                ErrorType.Validation => StatusCodes.Status400BadRequest,
+                ErrorType.Forbidden => StatusCodes.Status403Forbidden,
+                ErrorType.NotFound => StatusCodes.Status404NotFound,
+                ErrorType.Conflict => StatusCodes.Status409Conflict,
+                ErrorType.Failure => StatusCodes.Status400BadRequest,
+                ErrorType.Unexpected => StatusCodes.Status500InternalServerError,
+                _ => StatusCodes.Status500InternalServerError,
+            };
+
+            var problem = new ProblemDetails
+            {
+                Title = error.Type.ToString(),
+                Detail = error.Description,
+                Status = statusCode,
+                Type = $"https://httpstatuses.com/{statusCode}",
+            };
+
+            // Include the error code and any additional info in the extensions
+            problem.Extensions["code"] = error.Code;
+
+            return new ObjectResult(problem)
+            {
+                StatusCode = problem.Status,
+            };
+        }
+    }
+}

--- a/Extensions/Extensions.csproj
+++ b/Extensions/Extensions.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\ErrorOr.csproj" />
+      <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+</Project>

--- a/src/ErrorOr.csproj
+++ b/src/ErrorOr.csproj
@@ -26,11 +26,7 @@
     <AdditionalFiles Include="Stylecop.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference
-      Include="Microsoft.Bcl.HashCode"
-      Version="1.1.1"
-      Condition="'$(TargetFramework)' == 'netstandard2.0'"
-    />
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Nullable" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/tests/Extensions/AspNetCore/ControllerBaseExtensionsTests.cs.cs
+++ b/tests/Extensions/AspNetCore/ControllerBaseExtensionsTests.cs.cs
@@ -1,0 +1,155 @@
+using ErrorOr;
+using Extensions.AspNetCore;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Tests.Extensions.AspNetCore
+{
+    public class ControllerBaseExtensionsTests
+    {
+        private class TestController : ControllerBase
+        {
+        }
+
+        [Fact]
+        public void ConvertToActionResult_ReturnsOkObjectResult_WhenValue()
+        {
+            var controller = new TestController();
+            var result = Success(42);
+
+            var actionResult = controller.ConvertToActionResult(result);
+
+            var okResult = Assert.IsType<OkObjectResult>(actionResult.Result);
+            Assert.Equal(42, okResult.Value);
+        }
+
+        [Fact]
+        public void ConvertToActionResult_ReturnsProblemDetails_WhenError()
+        {
+            var controller = new TestController();
+            var result = Failure<int>("ERR01", "Something went wrong");
+
+            var actionResult = controller.ConvertToActionResult(result);
+
+            var objectResult = Assert.IsType<ObjectResult>(actionResult.Result);
+            var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+            Assert.Equal("ERR01", problem.Extensions["code"]);
+            Assert.Equal(400, problem.Status);
+        }
+
+        [Fact]
+        public void ConvertToActionResultWithoutData_ReturnsOk_WhenValue()
+        {
+            var controller = new TestController();
+            var result = Success("ok");
+
+            var actionResult = controller.ConvertToActionResultWithoutData(result);
+
+            Assert.IsType<OkResult>(actionResult);
+        }
+
+        [Fact]
+        public void ConvertToActionResultWithoutData_ReturnsProblem_WhenError()
+        {
+            var controller = new TestController();
+            var result = Failure<string>();
+
+            var actionResult = controller.ConvertToActionResultWithoutData(result);
+
+            var objectResult = Assert.IsType<ObjectResult>(actionResult);
+            var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+            Assert.Equal("ERR", problem.Extensions["code"]);
+        }
+
+        [Fact]
+        public void ConvertToActionResult_WithMapping_ReturnsMappedValue()
+        {
+            var controller = new TestController();
+            var result = Success(5);
+
+            var actionResult = controller.ConvertToActionResult<int, string>(result, v => $"Number {v}");
+
+            var okResult = Assert.IsType<OkObjectResult>(actionResult.Result);
+            Assert.Equal("Number 5", okResult.Value);
+        }
+
+        [Fact]
+        public async Task ConvertToActionResultAsync_ReturnsOk_WhenValue()
+        {
+            var controller = new TestController();
+            var result = Success(10);
+
+            var actionResult = await controller.ConvertToActionResultAsync<int, string>(result, async v =>
+            {
+                await Task.Delay(1);
+                return new OkObjectResult($"Val {v}");
+            });
+
+            var okResult = Assert.IsType<OkObjectResult>(actionResult.Result);
+            Assert.Equal("Val 10", okResult.Value);
+        }
+
+        [Fact]
+        public async Task ConvertToActionResultAsync_ReturnsProblem_WhenError()
+        {
+            var controller = new TestController();
+            var result = Failure<int>();
+
+            var actionResult = await controller.ConvertToActionResultAsync<int, string>(result, async v =>
+            {
+                await Task.Delay(1);
+                return new OkObjectResult(v.ToString());
+            });
+
+            var objectResult = Assert.IsType<ObjectResult>(actionResult.Result);
+            var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+            Assert.Equal("ERR", problem.Extensions["code"]);
+        }
+
+        [Fact]
+        public void ConvertToIActionResult_ReturnsOk_WhenValue()
+        {
+            var controller = new TestController();
+            var result = Success("hello");
+
+            var actionResult = controller.ConvertToIActionResult(result, v => v.ToUpper());
+
+            var okResult = Assert.IsType<OkObjectResult>(actionResult);
+            Assert.Equal("HELLO", okResult.Value);
+        }
+
+        [Fact]
+        public async Task ConvertToIActionResultAsync_ReturnsOk_WhenValue()
+        {
+            var controller = new TestController();
+            var result = Success(7);
+
+            var actionResult = await controller.ConvertToIActionResultAsync<int, int>(result, async v =>
+            {
+                await Task.Delay(1);
+                return v * 2;
+            });
+
+            var okResult = Assert.IsType<OkObjectResult>(actionResult);
+            Assert.Equal(14, okResult.Value);
+        }
+
+        private static ErrorOr<T> Success<T>(T value)
+        {
+            var ctor = typeof(ErrorOr<T>).GetConstructor(
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
+                null,
+                new Type[] { typeof(T) },
+                null);
+
+            if (ctor == null)
+            {
+                throw new InvalidOperationException("Private constructor for ErrorOr<T> not found.");
+            }
+
+            return (ErrorOr<T>)ctor.Invoke(new object[] { value! });
+        }
+
+        private static ErrorOr<T> Failure<T>(string code = "ERR", string description = "Error") =>
+            ErrorOr<T>.From(new List<Error> { Error.Validation(code, description) });
+    }
+}

--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -11,7 +11,8 @@
   <ItemGroup>
     <PackageReference Include="fluentassertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="xunit" Version="2.8.0" />
+      <FrameworkReference Include="Microsoft.AspNetCore.App" />
+      <PackageReference Include="xunit" Version="2.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -23,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Extensions\Extensions.csproj" />
     <ProjectReference Include="..\src\ErrorOr.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes #32

### Summary
This PR adds a new `ErrorOr.Extensions.AspNetCore` project which provides extension methods to convert `ErrorOr<T>` results into ASP.NET Core responses (both `ActionResult/IActionResult` for MVC-style controllers). It also includes comprehensive unit tests validating the conversion behavior.

The change implements the requested enhancement from #32 by providing convenient extension methods for consumers of ErrorOr to translate domain results into HTTP responses using `ProblemDetails` (RFC 7807) for error cases.

### What I added
- **New project:** `src/ErrorOr.Extensions.AspNetCore`
  - Contains `ControllerBaseExtensions.cs` with extension methods:
    - `ConvertToActionResult<T>` / `ConvertToActionResultWithoutData<T>`
    - `ConvertToActionResult<TIn,TOut>` (mapping)
    - Async variants: `ConvertToActionResultAsync`, `ConvertToIActionResultAsync`
    - `ConvertToIActionResult<TIn,TOut>` for `IActionResult` usage
    - `ConvertError` which returns standardized `ProblemDetails` and maps `ErrorType` → HTTP status codes
  - Uses `ProblemDetails` and stores `error.Code` in `ProblemDetails.Extensions["code"]`.

- **Tests:** `tests/Extensions/AspNetCore/ControllerBaseExtensionsTests.cs`
  - 6 unit tests covering:
    - success → `Ok`/`OkObjectResult`
    - error → `ObjectResult` with `ProblemDetails` and `code` in `Extensions`
    - mapping and async variants
  - All tests pass (`6/6`).

### Design notes
- I created the ASP.NET Core extensions in a **separate class library** (`ErrorOr.Extensions.AspNetCore`) and added a `FrameworkReference` to `Microsoft.AspNetCore.App`. This keeps the core `ErrorOr` library framework-agnostic (no direct dependency on ASP.NET Core).
- The extensions use `ProblemDetails` (RFC 7807) to return structured error responses and include the domain `error.Code` in `ProblemDetails.Extensions["code"]`.