### PR TITLE
Add Else/ElseAsync overloads returning ErrorOr

### DIFF
--- a/src/ErrorOr/ErrorOr.Else.cs
+++ b/src/ErrorOr/ErrorOr.Else.cs
@@ -65,6 +65,21 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// <summary>
     /// If the state is error, the provided function <paramref name="onError"/> is executed and its result is returned.
     /// </summary>
+    /// <param name="onError">The function to execute if the state is error.</param>
+    /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original <see cref="Value"/>.</returns>
+    public ErrorOr<TValue> Else(Func<List<Error>, ErrorOr<TValue>> onError)
+    {
+        if (!IsError)
+        {
+            return Value;
+        }
+
+        return onError(Errors);
+    }
+
+    /// <summary>
+    /// If the state is error, the provided function <paramref name="onError"/> is executed and its result is returned.
+    /// </summary>
     /// <param name="onError">The value to return if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original <see cref="Value"/>.</returns>
     public ErrorOr<TValue> Else(TValue onError)
@@ -83,6 +98,21 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original <see cref="Value"/>.</returns>
     public async Task<ErrorOr<TValue>> ElseAsync(Func<List<Error>, Task<TValue>> onError)
+    {
+        if (!IsError)
+        {
+            return Value;
+        }
+
+        return await onError(Errors).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// If the state is error, the provided function <paramref name="onError"/> is executed asynchronously and its result is returned.
+    /// </summary>
+    /// <param name="onError">The function to execute if the state is error.</param>
+    /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original <see cref="Value"/>.</returns>
+    public async Task<ErrorOr<TValue>> ElseAsync(Func<List<Error>, Task<ErrorOr<TValue>>> onError)
     {
         if (!IsError)
         {

--- a/src/ErrorOr/ErrorOr.ElseExtensions.cs
+++ b/src/ErrorOr/ErrorOr.ElseExtensions.cs
@@ -23,6 +23,20 @@ public static partial class ErrorOrExtensions
     /// <param name="errorOr">The <see cref="ErrorOr"/> instance.</param>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original value.</returns>
+    public static async Task<ErrorOr<TValue>> Else<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<List<Error>, ErrorOr<TValue>> onError)
+    {
+        var result = await errorOr.ConfigureAwait(false);
+
+        return result.Else(onError);
+    }
+
+    /// <summary>
+    /// If the state is error, the provided function <paramref name="onError"/> is executed asynchronously and its result is returned.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the underlying value in the <paramref name="errorOr"/>.</typeparam>
+    /// <param name="errorOr">The <see cref="ErrorOr"/> instance.</param>
+    /// <param name="onError">The function to execute if the state is error.</param>
+    /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original value.</returns>
     public static async Task<ErrorOr<TValue>> Else<TValue>(this Task<ErrorOr<TValue>> errorOr, TValue onError)
     {
         var result = await errorOr.ConfigureAwait(false);
@@ -38,6 +52,20 @@ public static partial class ErrorOrExtensions
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original value.</returns>
     public static async Task<ErrorOr<TValue>> ElseAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<List<Error>, Task<TValue>> onError)
+    {
+        var result = await errorOr.ConfigureAwait(false);
+
+        return await result.ElseAsync(onError).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// If the state is error, the provided function <paramref name="onError"/> is executed asynchronously and its result is returned.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the underlying value in the <paramref name="errorOr"/>.</typeparam>
+    /// <param name="errorOr">The <see cref="ErrorOr"/> instance.</param>
+    /// <param name="onError">The function to execute if the state is error.</param>
+    /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original value.</returns>
+    public static async Task<ErrorOr<TValue>> ElseAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<List<Error>, Task<ErrorOr<TValue>>> onError)
     {
         var result = await errorOr.ConfigureAwait(false);
 

--- a/tests/ErrorOr/ErrorOr.ElseAsyncTests.cs
+++ b/tests/ErrorOr/ErrorOr.ElseAsyncTests.cs
@@ -40,6 +40,45 @@ public class ElseAsyncTests
     }
 
     [Fact]
+    public async Task CallingElseAsyncWithValueFunc_WhenIsError_ShouldInvokeElseFunc_ButWithErrorOrReturn()
+    {
+        // Arrange
+        ErrorOr<string> errorOrString = Error.NotFound();
+
+        // Act
+        ErrorOr<string> GetNewValue() => "OK";
+
+        ErrorOr<string> result = await errorOrString
+            .ThenAsync(Convert.ToIntAsync)
+            .ThenAsync(Convert.ToStringAsync)
+            .ElseAsync(errors => Task.FromResult(GetNewValue()));
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.Should().BeEquivalentTo("OK");
+    }
+
+    [Fact]
+    public async Task CallingElseAsyncWithValueFunc_WhenIsError_ShouldInvokeElseFunc_ButWithErrorOrReturn_ContinueChainning()
+    {
+        // Arrange
+        ErrorOr<string> errorOrString = Error.NotFound();
+
+        // Act
+        ErrorOr<string> GetNewValue() => "OK";
+
+        ErrorOr<string> result = await errorOrString
+            .ThenAsync(Convert.ToIntAsync)
+            .ThenAsync(Convert.ToStringAsync)
+            .ElseAsync(errors => Task.FromResult(GetNewValue()))
+            .ThenAsync(value => Task.FromResult(value + "!"));
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.Should().BeEquivalentTo("OK!");
+    }
+
+    [Fact]
     public async Task CallingElseAsyncWithValue_WhenIsSuccess_ShouldNotReturnElseValue()
     {
         // Arrange

--- a/tests/ErrorOr/ErrorOr.ElseAsyncTests.cs
+++ b/tests/ErrorOr/ErrorOr.ElseAsyncTests.cs
@@ -59,6 +59,49 @@ public class ElseAsyncTests
     }
 
     [Fact]
+    public async Task CallingElseAsyncWithErrorOrValueFunc_WhenIsSuccess_ShouldNotInvokeElseFunc()
+    {
+        // Arrange
+        ErrorOr<string> errorOrString = "5";
+        bool elseFuncCalled = false;
+
+        // Act
+        ErrorOr<string> GetNewValue()
+        {
+            elseFuncCalled = true;
+            return "OK";
+        }
+
+        ErrorOr<string> result = await errorOrString
+            .ThenAsync(Convert.ToIntAsync)
+            .ThenAsync(Convert.ToStringAsync)
+            .ElseAsync(errors => Task.FromResult(GetNewValue()));
+
+        // Assert
+        elseFuncCalled.Should().BeFalse();
+        result.IsError.Should().BeFalse();
+        result.Value.Should().BeEquivalentTo(errorOrString.Value);
+    }
+
+    [Fact]
+    public async Task CallingElseAsyncWithErrorOrValueFunc_WhenIsError_ShouldInvokeElseFunc_AndReturnError()
+    {
+        // Arrange
+        ErrorOr<string> errorOrString = Error.NotFound();
+
+        // Act
+        ErrorOr<string> GetErrorValue() => Error.Unexpected();
+
+        ErrorOr<string> result = await errorOrString
+            .ThenAsync(Convert.ToIntAsync)
+            .ThenAsync(Convert.ToStringAsync)
+            .ElseAsync(errors => Task.FromResult(GetErrorValue()));
+
+        // Assert
+        result.IsError.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task CallingElseAsyncWithValueFunc_WhenIsError_ShouldInvokeElseFunc_ButWithErrorOrReturn_ContinueChaining()
     {
         // Arrange

--- a/tests/ErrorOr/ErrorOr.ElseAsyncTests.cs
+++ b/tests/ErrorOr/ErrorOr.ElseAsyncTests.cs
@@ -59,7 +59,7 @@ public class ElseAsyncTests
     }
 
     [Fact]
-    public async Task CallingElseAsyncWithValueFunc_WhenIsError_ShouldInvokeElseFunc_ButWithErrorOrReturn_ContinueChainning()
+    public async Task CallingElseAsyncWithValueFunc_WhenIsError_ShouldInvokeElseFunc_ButWithErrorOrReturn_ContinueChaining()
     {
         // Arrange
         ErrorOr<string> errorOrString = Error.NotFound();

--- a/tests/ErrorOr/ErrorOr.ElseTests.cs
+++ b/tests/ErrorOr/ErrorOr.ElseTests.cs
@@ -210,6 +210,45 @@ public class ElseTests
     }
 
     [Fact]
+    public async Task CallingElseWithValueFuncAfterThenAsync_WhenIsError_ShouldInvokeElseFunc_ButWithErrorOrReturn()
+    {
+        // Arrange
+        ErrorOr<string> errorOrString = Error.NotFound();
+
+        // Act
+        ErrorOr<string> GetNewValue() => "OK";
+
+        ErrorOr<string> result = await errorOrString
+            .Then(Convert.ToInt)
+            .ThenAsync(Convert.ToStringAsync)
+            .Else(errors => GetNewValue());
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.Should().BeEquivalentTo("OK");
+    }
+
+    [Fact]
+    public async Task CallingElseWithValueFuncAfterThenAsync_WhenIsError_ShouldInvokeElseFunc_ButWithErrorOrReturn_ContinueChainning()
+    {
+        // Arrange
+        ErrorOr<string> errorOrString = Error.NotFound();
+
+        // Act
+        ErrorOr<string> GetNewValue() => "OK";
+
+        ErrorOr<string> result = await errorOrString
+            .Then(Convert.ToInt)
+            .ThenAsync(Convert.ToStringAsync)
+            .Else(errors => GetNewValue())
+            .Then(value => value + "!");
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.Should().BeEquivalentTo("OK!");
+    }
+
+    [Fact]
     public async Task CallingElseWithErrorAfterThenAsync_WhenIsError_ShouldReturnElseError()
     {
         // Arrange

--- a/tests/ErrorOr/ErrorOr.ElseTests.cs
+++ b/tests/ErrorOr/ErrorOr.ElseTests.cs
@@ -229,7 +229,7 @@ public class ElseTests
     }
 
     [Fact]
-    public async Task CallingElseWithValueFuncAfterThenAsync_WhenIsError_ShouldInvokeElseFunc_ButWithErrorOrReturn_ContinueChainning()
+    public async Task CallingElseWithValueFuncAfterThenAsync_WhenIsError_ShouldInvokeElseFunc_ButWithErrorOrReturn_ContinueChaining()
     {
         // Arrange
         ErrorOr<string> errorOrString = Error.NotFound();


### PR DESCRIPTION
Introduce Else and ElseAsync overloads that accept functions returning ErrorOr<TValue> (sync and async) on the ErrorOr<TValue> type, plus corresponding Task-based extension methods. These overloads call the provided function when the state is error and otherwise return the original value. Tests were added to verify using value-returning Else/ElseAsync callbacks (including continuation after Then/ThenAsync) and to ensure chains continue correctly when the Else callback produces a success.