### PR TITLE
Make EmptyErrors.Instance return new List

### DIFF
--- a/src/ErrorOr/EmptyErrors.cs
+++ b/src/ErrorOr/EmptyErrors.cs
@@ -1,6 +1,6 @@
-﻿namespace ErrorOr;
+namespace ErrorOr;
 
 internal static class EmptyErrors
 {
-    public static List<Error> Instance { get; } = [];
+    public static List<Error> Instance => new();
 }


### PR DESCRIPTION
Replace the invalid initializer with an expression-bodied getter that returns a new List<Error> each call. This fix avoids a shared mutable list instance, and will not break the design, keeping the backward compatibility.