### PR TITLE
feat: Add Recover with async extensions and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,7 +596,7 @@ You can mix `Then`, `FailIf`, `Recover`, `Else`, `Switch` and `Match` methods to
 ErrorOr<string> foo = await result
     .ThenDoAsync(val => Task.Delay(val))
     .FailIf(val => val > 2, Error.Validation(description: $"{val} is too big"))
-    .Recover(errors => Error.Unexpected(description: $"Recovered from {errors.Count} errors"))
+    .Recover(errors => 1)
     .ThenDo(val => Console.WriteLine($"Finished waiting {val} seconds."))
     .ThenAsync(val => Task.FromResult(val * 2))
     .Then(val => $"The result is {val}")

--- a/README.md
+++ b/README.md
@@ -52,10 +52,13 @@
     - [`ThenDo` and `ThenDoAsync`](#thendo-and-thendoasync)
     - [Mixing `Then`, `ThenDo`, `ThenAsync`, `ThenDoAsync`](#mixing-then-thendo-thenasync-thendoasync)
   - [`FailIf`](#failif)
+  - [`Recover`](#recover)
+    - [`Recover`](#recover-1)
+    - [`RecoverAsync`](#recoverasync)
   - [`Else`](#else)
     - [`Else`](#else-1)
     - [`ElseAsync`](#elseasync)
-- [Mixing Features (`Then`, `FailIf`, `Else`, `Switch`, `Match`)](#mixing-features-then-failif-else-switch-match)
+- [Mixing Features (`Then`, `FailIf`, `Recover`, `Else`, `Switch`, `Match`)](#mixing-features-then-failif-recover-else-switch-match)
 - [Error Types](#error-types)
   - [Built in error types](#built-in-error-types)
   - [Custom error types](#custom-error-types)
@@ -567,14 +570,33 @@ ErrorOr<string> foo = await result
     .ElseAsync(errors => Task.FromResult($"{errors.Count} errors occurred."));
 ```
 
-# Mixing Features (`Then`, `FailIf`, `Else`, `Switch`, `Match`)
+## `Recover`
 
-You can mix `Then`, `FailIf`, `Else`, `Switch` and `Match` methods together.
+`Recover` receives a function. If the result is an error, `Recover` invokes the function and returns its result. Otherwise, it returns the original value.
+
+### `Recover`
+
+```cs
+ErrorOr<string> foo = result
+    .Recover(errors => $"Recovered from {errors.Count} errors.");
+```
+
+### `RecoverAsync`
+
+```cs
+ErrorOr<string> foo = await result
+    .RecoverAsync(errors => Task.FromResult<ErrorOr<string>>($"Recovered from {errors.Count} errors."));
+```
+
+# Mixing Features (`Then`, `FailIf`, `Recover`, `Else`, `Switch`, `Match`)
+
+You can mix `Then`, `FailIf`, `Recover`, `Else`, `Switch` and `Match` methods together.
 
 ```cs
 ErrorOr<string> foo = await result
     .ThenDoAsync(val => Task.Delay(val))
     .FailIf(val => val > 2, Error.Validation(description: $"{val} is too big"))
+    .Recover(errors => Error.Unexpected(description: $"Recovered from {errors.Count} errors"))
     .ThenDo(val => Console.WriteLine($"Finished waiting {val} seconds."))
     .ThenAsync(val => Task.FromResult(val * 2))
     .Then(val => $"The result is {val}")

--- a/src/ErrorOr/ErrorOr.Recover.cs
+++ b/src/ErrorOr/ErrorOr.Recover.cs
@@ -1,0 +1,34 @@
+namespace ErrorOr;
+
+public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
+{
+    /// <summary>
+    /// If the state is error, the provided function <paramref name="onError"/> is executed and its result is returned.
+    /// </summary>
+    /// <param name="onError">The function to execute if the state is error.</param>
+    /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original <see cref="Value"/>.</returns>
+    public ErrorOr<TValue> Recover(Func<List<Error>, ErrorOr<TValue>> onError)
+    {
+        if (!IsError)
+        {
+            return Value;
+        }
+
+        return onError(Errors);
+    }
+
+    /// <summary>
+    /// If the state is error, the provided function <paramref name="onError"/> is executed asynchronously and its result is returned.
+    /// </summary>
+    /// <param name="onError">The function to execute if the state is error.</param>
+    /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original <see cref="Value"/>.</returns>
+    public async Task<ErrorOr<TValue>> RecoverAsync(Func<List<Error>, Task<ErrorOr<TValue>>> onError)
+    {
+        if (!IsError)
+        {
+            return Value;
+        }
+
+        return await onError(Errors).ConfigureAwait(false);
+    }
+}

--- a/src/ErrorOr/ErrorOr.RecoverExtensions.cs
+++ b/src/ErrorOr/ErrorOr.RecoverExtensions.cs
@@ -1,0 +1,36 @@
+namespace ErrorOr;
+
+public static partial class ErrorOrExtensions
+{
+    /// <summary>
+    /// If the state of <paramref name="errorOr"/> is error, the provided function <paramref name="onError"/> is executed and its result is returned.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the underlying value in the <paramref name="errorOr"/>.</typeparam>
+    /// <param name="errorOr">The <see cref="ErrorOr"/> instance.</param>
+    /// <param name="onError">The function to execute if the state is error.</param>
+    /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original value.</returns>
+    public static async Task<ErrorOr<TValue>> Recover<TValue>(
+        this Task<ErrorOr<TValue>> errorOr,
+        Func<List<Error>, ErrorOr<TValue>> onError)
+    {
+        var result = await errorOr.ConfigureAwait(false);
+
+        return result.Recover(onError);
+    }
+
+    /// <summary>
+    /// If the state of <paramref name="errorOr"/> is error, the provided function <paramref name="onError"/> is executed asynchronously and its result is returned.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the underlying value in the <paramref name="errorOr"/>.</typeparam>
+    /// <param name="errorOr">The <see cref="ErrorOr"/> instance.</param>
+    /// <param name="onError">The function to execute if the state is error.</param>
+    /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original value.</returns>
+    public static async Task<ErrorOr<TValue>> RecoverAsync<TValue>(
+        this Task<ErrorOr<TValue>> errorOr,
+        Func<List<Error>, Task<ErrorOr<TValue>>> onError)
+    {
+        var result = await errorOr.ConfigureAwait(false);
+
+        return await result.RecoverAsync(onError).ConfigureAwait(false);
+    }
+}

--- a/tests/ErrorOr/ErrorOr.RecoverAsyncTests.cs
+++ b/tests/ErrorOr/ErrorOr.RecoverAsyncTests.cs
@@ -1,0 +1,108 @@
+using ErrorOr;
+using FluentAssertions;
+
+namespace Tests;
+
+public class RecoverAsyncTests
+{
+    [Fact]
+    public async Task CallingRecoverAsync_WhenIsSuccess_ShouldNotInvokeRecoverFunc()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = 5;
+        var recoverInvoked = false;
+
+        // Act
+        ErrorOr<int> result = await errorOrInt
+            .RecoverAsync(_ =>
+            {
+                recoverInvoked = true;
+                return Task.FromResult<ErrorOr<int>>(10);
+            });
+
+        // Assert
+        recoverInvoked.Should().BeFalse();
+        result.IsError.Should().BeFalse();
+        result.Value.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task CallingRecoverAsync_WhenIsError_ShouldInvokeRecoverFuncAndReturnValue()
+    {
+        // Arrange
+        ErrorOr<string> errorOrString = Error.NotFound();
+
+        // Act
+        ErrorOr<string> result = await errorOrString
+            .RecoverAsync(errors => Task.FromResult<ErrorOr<string>>($"Recovered with {errors.Count} errors"));
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.Should().Be("Recovered with 1 errors");
+    }
+
+    [Fact]
+    public async Task CallingRecoverAsync_WhenIsError_ShouldInvokeRecoverFuncAndReturnError()
+    {
+        // Arrange
+        ErrorOr<string> errorOrString = Error.NotFound();
+
+        // Act
+        ErrorOr<string> result = await errorOrString
+            .RecoverAsync(_ => Task.FromResult<ErrorOr<string>>(Error.Conflict()));
+
+        // Assert
+        result.IsError.Should().BeTrue();
+        result.FirstError.Type.Should().Be(ErrorType.Conflict);
+    }
+
+    [Fact]
+    public async Task CallingRecoverAsyncExtensionMethod_WhenIsSuccess_ShouldNotInvokeRecoverFunc()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = 5;
+        var recoverInvoked = false;
+
+        // Act
+        ErrorOr<int> result = await Task.FromResult(errorOrInt)
+            .RecoverAsync(_ =>
+            {
+                recoverInvoked = true;
+                return Task.FromResult<ErrorOr<int>>(10);
+            });
+
+        // Assert
+        recoverInvoked.Should().BeFalse();
+        result.IsError.Should().BeFalse();
+        result.Value.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task CallingRecoverAsyncExtensionMethod_WhenIsError_ShouldPassOriginalErrorsToRecoverFunc()
+    {
+        // Arrange
+        var originalErrors = new List<Error>
+        {
+            Error.NotFound(),
+            Error.Validation(),
+        };
+        ErrorOr<string> errorOrString = originalErrors;
+        var passedErrorsCount = 0;
+        var passedFirstErrorType = ErrorType.Unexpected;
+
+        // Act
+        ErrorOr<string> result = await Task.FromResult(errorOrString)
+            .RecoverAsync(errors =>
+            {
+                passedErrorsCount = errors.Count;
+                passedFirstErrorType = errors[0].Type;
+                return Task.FromResult<ErrorOr<string>>(Error.Unexpected());
+            });
+
+        // Assert
+        passedErrorsCount.Should().Be(2);
+        passedFirstErrorType.Should().Be(ErrorType.NotFound);
+        result.IsError.Should().BeTrue();
+        result.FirstError.Type.Should().Be(ErrorType.Unexpected);
+    }
+}

--- a/tests/ErrorOr/ErrorOr.RecoverTests.cs
+++ b/tests/ErrorOr/ErrorOr.RecoverTests.cs
@@ -1,0 +1,108 @@
+using ErrorOr;
+using FluentAssertions;
+
+namespace Tests;
+
+public class RecoverTests
+{
+    [Fact]
+    public void CallingRecover_WhenIsSuccess_ShouldNotInvokeRecoverFunc()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = 5;
+        var recoverInvoked = false;
+
+        // Act
+        ErrorOr<int> result = errorOrInt
+            .Recover(_ =>
+            {
+                recoverInvoked = true;
+                return 10;
+            });
+
+        // Assert
+        recoverInvoked.Should().BeFalse();
+        result.IsError.Should().BeFalse();
+        result.Value.Should().Be(5);
+    }
+
+    [Fact]
+    public void CallingRecover_WhenIsError_ShouldInvokeRecoverFuncAndReturnValue()
+    {
+        // Arrange
+        ErrorOr<string> errorOrString = Error.NotFound();
+
+        // Act
+        ErrorOr<string> result = errorOrString
+            .Recover(errors => $"Error count: {errors.Count}");
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.Should().Be("Error count: 1");
+    }
+
+    [Fact]
+    public void CallingRecover_WhenIsError_ShouldInvokeRecoverFuncAndReturnError()
+    {
+        // Arrange
+        ErrorOr<string> errorOrString = Error.NotFound();
+
+        // Act
+        ErrorOr<string> result = errorOrString
+            .Recover(_ => Error.Unexpected());
+
+        // Assert
+        result.IsError.Should().BeTrue();
+        result.FirstError.Type.Should().Be(ErrorType.Unexpected);
+    }
+
+    [Fact]
+    public async Task CallingRecoverExtensionMethod_WhenIsSuccess_ShouldNotInvokeRecoverFunc()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = 5;
+        var recoverInvoked = false;
+
+        // Act
+        ErrorOr<int> result = await Task.FromResult(errorOrInt)
+            .Recover(_ =>
+            {
+                recoverInvoked = true;
+                return 10;
+            });
+
+        // Assert
+        recoverInvoked.Should().BeFalse();
+        result.IsError.Should().BeFalse();
+        result.Value.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task CallingRecoverExtensionMethod_WhenIsError_ShouldPassOriginalErrorsToRecoverFunc()
+    {
+        // Arrange
+        var originalErrors = new List<Error>
+        {
+            Error.NotFound(description: "missing"),
+            Error.Validation(description: "invalid"),
+        };
+        ErrorOr<string> errorOrString = originalErrors;
+        var passedErrorsCount = 0;
+        var passedFirstErrorType = ErrorType.Unexpected;
+
+        // Act
+        ErrorOr<string> result = await Task.FromResult(errorOrString)
+            .Recover(errors =>
+            {
+                passedErrorsCount = errors.Count;
+                passedFirstErrorType = errors[0].Type;
+                return $"Recovered with {errors.Count} errors";
+            });
+
+        // Assert
+        passedErrorsCount.Should().Be(2);
+        passedFirstErrorType.Should().Be(ErrorType.NotFound);
+        result.IsError.Should().BeFalse();
+        result.Value.Should().Be("Recovered with 2 errors");
+    }
+}


### PR DESCRIPTION
Currently, there is no way to provide alternative branching logic when there is a failure. That is, there is no way to recover. Think `cache miss -> call db`.

To address the gap a new "Recover" feature can be added to the `ErrorOr` library, allowing consumers to handle error states by providing recovery logic, both synchronously and asynchronously. The changes include the implementation of `Recover` and `RecoverAsync` methods, extension methods for use with `Task<ErrorOr<TValue>>`, comprehensive documentation updates, and unit tests to ensure correct behavior.


```csharp
cache.GetUser(userId).Recover(_ => db.GetUser(userId).Then(cache.Save));
```

In more complex scenarios where the errors need to be inspected for the path the consumer can do the following:

```csharp
cache.GetUser(userId)
    .Recover(errors => errors.Any(error => error.Type == ErrorType.NotFound)
        ? db.GetUser(userId).Then(cache.Save)
        : errors)
```

---

**New Recover Feature Implementation:**

* Added `Recover` and `RecoverAsync` methods to `ErrorOr<TValue>`, allowing users to recover from errors by providing custom logic to handle error states.
* Introduced extension methods for `Task<ErrorOr<TValue>>` to support fluent async recovery with `Recover` and `RecoverAsync`.

**Documentation Updates:**

* Updated `README.md` to document the new `Recover` and `RecoverAsync` methods, including usage examples and updates to feature-mixing sections. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R55-R61) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L570-R599)

**Testing:**

* Added unit tests in `ErrorOr.RecoverTests.cs` to verify the behavior of the synchronous `Recover` method and its extension.
* Added unit tests in `ErrorOr.RecoverAsyncTests.cs` to verify the behavior of the asynchronous `RecoverAsync` method and its extension.