### PR TITLE
feat: Add ThenEnsure and ThenEnsureAsync with tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
     - [`ThenAsync`](#thenasync)
     - [`ThenDo` and `ThenDoAsync`](#thendo-and-thendoasync)
     - [`ThenEnsure` and `ThenEnsureAsync`](#thenensure-and-thenensureasync)
-    - [Mixing `Then`, `ThenDo`, `ThenEnsure`, `ThenAsync`, `ThenDoAsync`, `ThenEnsureAsync`](#mixing-then-thendo-thenensure-thenasync-thendoasync-thenensureasync)
+    - [Mixing `Then`, `ThenDo`, `ThenAsync`, `ThenDoAsync`](#mixing-then-thendo-thenasync-thendoasync)
   - [`FailIf`](#failif)
   - [`Else`](#else)
     - [`Else`](#else-1)
@@ -510,37 +510,46 @@ ErrorOr<string> foo = await result
 ### `ThenEnsure` and `ThenEnsureAsync`
 
 `ThenEnsure` and `ThenEnsureAsync` are similar to `ThenDo` and `ThenDoAsync`, but they receive a function that can return errors.
-If no errors are returned, the original value is preserved.
+If no errors are returned, the original value is preserved and the ensure function's success value is ignored.
 
 ```cs
-ErrorOr<string> foo = result
-    .ThenEnsure(val => val.Length > 3
-        ? Error.Validation(description: "Value is too long")
-        : val.ToUpperInvariant())
-    .Then(val => $"The result is {val}");
+ErrorOr<Success> CacheUser(User user)
+{
+    return _cache.Set(user);
+}
+
+ErrorOr<User> userOrError = _userRepository
+    .GetById(userId)
+    .ThenEnsure(CacheUser);
+
+// Success: userOrError is the original user from GetById.
+// Failure: userOrError contains cache errors from CacheUser.
 ```
 
 ```cs
-ErrorOr<string> foo = await result
-    .ThenEnsureAsync(val => Task.FromResult<ErrorOr<string>>(
-        val.Length > 3
-            ? Error.Validation(description: "Value is too long")
-            : val.ToUpperInvariant()))
-    .Then(val => $"The result is {val}");
+Task<ErrorOr<Success>> CacheUserAsync(User user)
+{
+    return _cache.SetAsync(user);
+}
+
+ErrorOr<User> userOrError = await _userRepository
+    .GetByIdAsync(userId)
+    .ThenEnsureAsync(CacheUserAsync);
+
+// Success: userOrError is the original user from GetByIdAsync.
+// Failure: userOrError contains cache errors from EnsureUserIsCachedAsync.
 ```
 
-### Mixing `Then`, `ThenDo`, `ThenEnsure`, `ThenAsync`, `ThenDoAsync`, `ThenEnsureAsync`
+### Mixing `Then`, `ThenDo`, `ThenAsync`, `ThenDoAsync`
 
-You can mix and match `Then`, `ThenDo`, `ThenEnsure`, `ThenAsync`, `ThenDoAsync`, `ThenEnsureAsync` methods.
+You can mix and match `Then`, `ThenDo`, `ThenAsync`, `ThenDoAsync` methods.
 
 ```cs
 ErrorOr<string> foo = await result
     .ThenDoAsync(val => Task.Delay(val))
-    .ThenEnsure(val => val > 10 ? Error.Validation(description: "Value is too big") : val)
     .Then(val => val * 2)
     .ThenAsync(val => DoSomethingAsync(val))
     .ThenDo(val => Console.WriteLine($"Finsihed waiting {val} seconds."))
-    .ThenEnsureAsync(val => Task.FromResult<ErrorOr<int>>(val < 0 ? Error.Validation(description: "Value must be positive") : val))
     .ThenAsync(val => Task.FromResult(val * 2))
     .Then(val => $"The result is {val}");
 ```

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@
     - [`Then`](#then-1)
     - [`ThenAsync`](#thenasync)
     - [`ThenDo` and `ThenDoAsync`](#thendo-and-thendoasync)
-    - [Mixing `Then`, `ThenDo`, `ThenAsync`, `ThenDoAsync`](#mixing-then-thendo-thenasync-thendoasync)
+    - [`ThenEnsure` and `ThenEnsureAsync`](#thenensure-and-thenensureasync)
+    - [Mixing `Then`, `ThenDo`, `ThenEnsure`, `ThenAsync`, `ThenDoAsync`, `ThenEnsureAsync`](#mixing-then-thendo-thenensure-thenasync-thendoasync-thenensureasync)
   - [`FailIf`](#failif)
   - [`Else`](#else)
     - [`Else`](#else-1)
@@ -506,16 +507,40 @@ ErrorOr<string> foo = await result
     .ThenDo(val => $"The result is {val}");
 ```
 
-### Mixing `Then`, `ThenDo`, `ThenAsync`, `ThenDoAsync`
+### `ThenEnsure` and `ThenEnsureAsync`
 
-You can mix and match `Then`, `ThenDo`, `ThenAsync`, `ThenDoAsync` methods.
+`ThenEnsure` and `ThenEnsureAsync` are similar to `ThenDo` and `ThenDoAsync`, but they receive a function that can return errors.
+If no errors are returned, the original value is preserved.
+
+```cs
+ErrorOr<string> foo = result
+    .ThenEnsure(val => val.Length > 3
+        ? Error.Validation(description: "Value is too long")
+        : val.ToUpperInvariant())
+    .Then(val => $"The result is {val}");
+```
+
+```cs
+ErrorOr<string> foo = await result
+    .ThenEnsureAsync(val => Task.FromResult<ErrorOr<string>>(
+        val.Length > 3
+            ? Error.Validation(description: "Value is too long")
+            : val.ToUpperInvariant()))
+    .Then(val => $"The result is {val}");
+```
+
+### Mixing `Then`, `ThenDo`, `ThenEnsure`, `ThenAsync`, `ThenDoAsync`, `ThenEnsureAsync`
+
+You can mix and match `Then`, `ThenDo`, `ThenEnsure`, `ThenAsync`, `ThenDoAsync`, `ThenEnsureAsync` methods.
 
 ```cs
 ErrorOr<string> foo = await result
     .ThenDoAsync(val => Task.Delay(val))
+    .ThenEnsure(val => val > 10 ? Error.Validation(description: "Value is too big") : val)
     .Then(val => val * 2)
     .ThenAsync(val => DoSomethingAsync(val))
     .ThenDo(val => Console.WriteLine($"Finsihed waiting {val} seconds."))
+    .ThenEnsureAsync(val => Task.FromResult<ErrorOr<int>>(val < 0 ? Error.Validation(description: "Value must be positive") : val))
     .ThenAsync(val => Task.FromResult(val * 2))
     .Then(val => $"The result is {val}");
 ```

--- a/README.md
+++ b/README.md
@@ -513,9 +513,10 @@ ErrorOr<string> foo = await result
 If no errors are returned, the original value is preserved and the ensure function's success value is ignored.
 
 ```cs
-ErrorOr<Success> CacheUser(User user)
+ErrorOr<User> CacheUser(User user)
 {
-    return _cache.Set(user);
+    ErrorOr<Success> result = _cache.Set(user);
+    return result.IsError ? result.Errors : user;
 }
 
 ErrorOr<User> userOrError = _userRepository
@@ -527,9 +528,10 @@ ErrorOr<User> userOrError = _userRepository
 ```
 
 ```cs
-Task<ErrorOr<Success>> CacheUserAsync(User user)
+async Task<ErrorOr<User>> CacheUserAsync(User user)
 {
-    return _cache.SetAsync(user);
+    ErrorOr<Success> result = await _cache.SetAsync(user);
+    return result.IsError ? result.Errors : user;
 }
 
 ErrorOr<User> userOrError = await _userRepository
@@ -537,7 +539,7 @@ ErrorOr<User> userOrError = await _userRepository
     .ThenEnsureAsync(CacheUserAsync);
 
 // Success: userOrError is the original user from GetByIdAsync.
-// Failure: userOrError contains cache errors from EnsureUserIsCachedAsync.
+// Failure: userOrError contains cache errors from CacheUserAsync.
 ```
 
 ### Mixing `Then`, `ThenDo`, `ThenAsync`, `ThenDoAsync`

--- a/src/ErrorOr/ErrorOr.Then.cs
+++ b/src/ErrorOr/ErrorOr.Then.cs
@@ -36,24 +36,6 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     }
 
     /// <summary>
-    /// If the state is a value, the provided function <paramref name="onValue"/> is executed and its errors are returned.
-    /// If no errors are returned, the original value is returned.
-    /// </summary>
-    /// <param name="onValue">The function to execute if the state is a value.</param>
-    /// <returns>The errors from calling <paramref name="onValue"/> if state is value and errors are returned; otherwise the original <see cref="ErrorOr"/> instance.</returns>
-    public ErrorOr<TValue> ThenEnsure(Func<TValue, ErrorOr<TValue>> onValue)
-    {
-        if (IsError)
-        {
-            return Errors;
-        }
-
-        ErrorOr<TValue> result = onValue(Value);
-
-        return result.IsError ? result.Errors : this;
-    }
-
-    /// <summary>
     /// If the state is a value, the provided function <paramref name="onValue"/> is executed and its result is returned.
     /// </summary>
     /// <typeparam name="TNextValue">The type of the result.</typeparam>
@@ -103,6 +85,40 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     }
 
     /// <summary>
+    /// If the state is a value, the provided function <paramref name="onValue"/> is executed asynchronously and its result is returned.
+    /// </summary>
+    /// <typeparam name="TNextValue">The type of the result.</typeparam>
+    /// <param name="onValue">The function to execute if the state is a value.</param>
+    /// <returns>The result from calling <paramref name="onValue"/> if state is value; otherwise the original <see cref="Errors"/>.</returns>
+    public async Task<ErrorOr<TNextValue>> ThenAsync<TNextValue>(Func<TValue, Task<TNextValue>> onValue)
+    {
+        if (IsError)
+        {
+            return Errors;
+        }
+
+        return await onValue(Value).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// If the state is a value, the provided function <paramref name="onValue"/> is executed and its errors are returned.
+    /// If no errors are returned, the original value is returned.
+    /// </summary>
+    /// <param name="onValue">The function to execute if the state is a value.</param>
+    /// <returns>The errors from calling <paramref name="onValue"/> if state is value and errors are returned; otherwise the original <see cref="ErrorOr"/> instance.</returns>
+    public ErrorOr<TValue> ThenEnsure(Func<TValue, ErrorOr<TValue>> onValue)
+    {
+        if (IsError)
+        {
+            return Errors;
+        }
+
+        ErrorOr<TValue> result = onValue(Value);
+
+        return result.IsError ? result.Errors : this;
+    }
+
+    /// <summary>
     /// If the state is a value, the provided function <paramref name="onValue"/> is executed asynchronously and its errors are returned.
     /// If no errors are returned, the original value is returned.
     /// </summary>
@@ -118,21 +134,5 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
         ErrorOr<TValue> result = await onValue(Value).ConfigureAwait(false);
 
         return result.IsError ? result.Errors : this;
-    }
-
-    /// <summary>
-    /// If the state is a value, the provided function <paramref name="onValue"/> is executed asynchronously and its result is returned.
-    /// </summary>
-    /// <typeparam name="TNextValue">The type of the result.</typeparam>
-    /// <param name="onValue">The function to execute if the state is a value.</param>
-    /// <returns>The result from calling <paramref name="onValue"/> if state is value; otherwise the original <see cref="Errors"/>.</returns>
-    public async Task<ErrorOr<TNextValue>> ThenAsync<TNextValue>(Func<TValue, Task<TNextValue>> onValue)
-    {
-        if (IsError)
-        {
-            return Errors;
-        }
-
-        return await onValue(Value).ConfigureAwait(false);
     }
 }

--- a/src/ErrorOr/ErrorOr.Then.cs
+++ b/src/ErrorOr/ErrorOr.Then.cs
@@ -36,6 +36,24 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     }
 
     /// <summary>
+    /// If the state is a value, the provided function <paramref name="onValue"/> is executed and its errors are returned.
+    /// If no errors are returned, the original value is returned.
+    /// </summary>
+    /// <param name="onValue">The function to execute if the state is a value.</param>
+    /// <returns>The errors from calling <paramref name="onValue"/> if state is value and errors are returned; otherwise the original <see cref="ErrorOr"/> instance.</returns>
+    public ErrorOr<TValue> ThenEnsure(Func<TValue, ErrorOr<TValue>> onValue)
+    {
+        if (IsError)
+        {
+            return Errors;
+        }
+
+        ErrorOr<TValue> result = onValue(Value);
+
+        return result.IsError ? result.Errors : this;
+    }
+
+    /// <summary>
     /// If the state is a value, the provided function <paramref name="onValue"/> is executed and its result is returned.
     /// </summary>
     /// <typeparam name="TNextValue">The type of the result.</typeparam>
@@ -82,6 +100,24 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
         await action(Value).ConfigureAwait(false);
 
         return this;
+    }
+
+    /// <summary>
+    /// If the state is a value, the provided function <paramref name="onValue"/> is executed asynchronously and its errors are returned.
+    /// If no errors are returned, the original value is returned.
+    /// </summary>
+    /// <param name="onValue">The function to execute if the state is a value.</param>
+    /// <returns>The errors from calling <paramref name="onValue"/> if state is value and errors are returned; otherwise the original <see cref="ErrorOr"/> instance.</returns>
+    public async Task<ErrorOr<TValue>> ThenEnsureAsync(Func<TValue, Task<ErrorOr<TValue>>> onValue)
+    {
+        if (IsError)
+        {
+            return Errors;
+        }
+
+        ErrorOr<TValue> result = await onValue(Value).ConfigureAwait(false);
+
+        return result.IsError ? result.Errors : this;
     }
 
     /// <summary>

--- a/src/ErrorOr/ErrorOr.ThenExtensions.cs
+++ b/src/ErrorOr/ErrorOr.ThenExtensions.cs
@@ -47,6 +47,21 @@ public static partial class ErrorOrExtensions
     }
 
     /// <summary>
+    /// If the state of <paramref name="errorOr"/> is a value, the provided function <paramref name="onValue"/> is executed and its errors are returned.
+    /// If no errors are returned, the original value is returned.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the underlying value in the <paramref name="errorOr"/>.</typeparam>
+    /// <param name="errorOr">The <see cref="ErrorOr"/> instance.</param>
+    /// <param name="onValue">The function to execute if the state is a value.</param>
+    /// <returns>The errors from calling <paramref name="onValue"/> if state is value and errors are returned; otherwise the original <paramref name="errorOr"/>.</returns>
+    public static async Task<ErrorOr<TValue>> ThenEnsure<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, ErrorOr<TValue>> onValue)
+    {
+        var result = await errorOr.ConfigureAwait(false);
+
+        return result.ThenEnsure(onValue);
+    }
+
+    /// <summary>
     /// If the state of <paramref name="errorOr"/> is a value, the provided function <paramref name="onValue"/> is executed asynchronously and its result is returned.
     /// </summary>
     /// <typeparam name="TValue">The type of the underlying value in the <paramref name="errorOr"/>.</typeparam>
@@ -88,5 +103,20 @@ public static partial class ErrorOrExtensions
         var result = await errorOr.ConfigureAwait(false);
 
         return await result.ThenDoAsync(action).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// If the state of <paramref name="errorOr"/> is a value, the provided function <paramref name="onValue"/> is executed asynchronously and its errors are returned.
+    /// If no errors are returned, the original value is returned.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the underlying value in the <paramref name="errorOr"/>.</typeparam>
+    /// <param name="errorOr">The <see cref="ErrorOr"/> instance.</param>
+    /// <param name="onValue">The function to execute if the state is a value.</param>
+    /// <returns>The errors from calling <paramref name="onValue"/> if state is value and errors are returned; otherwise the original <paramref name="errorOr"/>.</returns>
+    public static async Task<ErrorOr<TValue>> ThenEnsureAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task<ErrorOr<TValue>>> onValue)
+    {
+        var result = await errorOr.ConfigureAwait(false);
+
+        return await result.ThenEnsureAsync(onValue).ConfigureAwait(false);
     }
 }

--- a/src/ErrorOr/ErrorOr.ThenExtensions.cs
+++ b/src/ErrorOr/ErrorOr.ThenExtensions.cs
@@ -47,21 +47,6 @@ public static partial class ErrorOrExtensions
     }
 
     /// <summary>
-    /// If the state of <paramref name="errorOr"/> is a value, the provided function <paramref name="onValue"/> is executed and its errors are returned.
-    /// If no errors are returned, the original value is returned.
-    /// </summary>
-    /// <typeparam name="TValue">The type of the underlying value in the <paramref name="errorOr"/>.</typeparam>
-    /// <param name="errorOr">The <see cref="ErrorOr"/> instance.</param>
-    /// <param name="onValue">The function to execute if the state is a value.</param>
-    /// <returns>The errors from calling <paramref name="onValue"/> if state is value and errors are returned; otherwise the original <paramref name="errorOr"/>.</returns>
-    public static async Task<ErrorOr<TValue>> ThenEnsure<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, ErrorOr<TValue>> onValue)
-    {
-        var result = await errorOr.ConfigureAwait(false);
-
-        return result.ThenEnsure(onValue);
-    }
-
-    /// <summary>
     /// If the state of <paramref name="errorOr"/> is a value, the provided function <paramref name="onValue"/> is executed asynchronously and its result is returned.
     /// </summary>
     /// <typeparam name="TValue">The type of the underlying value in the <paramref name="errorOr"/>.</typeparam>
@@ -103,6 +88,21 @@ public static partial class ErrorOrExtensions
         var result = await errorOr.ConfigureAwait(false);
 
         return await result.ThenDoAsync(action).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// If the state of <paramref name="errorOr"/> is a value, the provided function <paramref name="onValue"/> is executed and its errors are returned.
+    /// If no errors are returned, the original value is returned.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the underlying value in the <paramref name="errorOr"/>.</typeparam>
+    /// <param name="errorOr">The <see cref="ErrorOr"/> instance.</param>
+    /// <param name="onValue">The function to execute if the state is a value.</param>
+    /// <returns>The errors from calling <paramref name="onValue"/> if state is value and errors are returned; otherwise the original <paramref name="errorOr"/>.</returns>
+    public static async Task<ErrorOr<TValue>> ThenEnsure<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, ErrorOr<TValue>> onValue)
+    {
+        var result = await errorOr.ConfigureAwait(false);
+
+        return result.ThenEnsure(onValue);
     }
 
     /// <summary>

--- a/tests/ErrorOr/ErrorOr.ThenEnsureAsyncTests.cs
+++ b/tests/ErrorOr/ErrorOr.ThenEnsureAsyncTests.cs
@@ -58,6 +58,63 @@ public class ThenEnsureAsyncTests
     }
 
     [Fact]
+    public async Task CallingThenEnsureAsyncAfterThenAsync_WhenEnsureSucceeds_ShouldContinueChainWithOriginalValue()
+    {
+        // Arrange
+        ErrorOr<string> errorOrString = "5";
+        int valueFromThenDo = 0;
+
+        // Act
+        ErrorOr<string> result = await errorOrString
+            .ThenAsync(Convert.ToIntAsync)
+            .Then(num => num * 2)
+            .ThenEnsureAsync(num => Task.FromResult<ErrorOr<int>>(num > 3 ? num + 100 : Error.Validation()))
+            .ThenDoAsync(num =>
+            {
+                valueFromThenDo = num;
+                return Task.CompletedTask;
+            })
+            .Then(Convert.ToString);
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.Should().Be("10");
+        valueFromThenDo.Should().Be(10);
+    }
+
+    [Fact]
+    public async Task CallingThenEnsureAsyncAfterThenAsync_WhenEnsureReturnsError_ShouldNotInvokeLaterChain()
+    {
+        // Arrange
+        ErrorOr<string> errorOrString = "5";
+        bool thenDoCalled = false;
+        bool thenCalled = false;
+
+        // Act
+        ErrorOr<string> result = await errorOrString
+            .ThenAsync(Convert.ToIntAsync)
+            .Then(num => num + 1)
+            .ThenEnsureAsync(num => Task.FromResult<ErrorOr<int>>(num > 3 ? Error.Validation(description: $"{num} is too big") : num))
+            .ThenDoAsync(_ =>
+            {
+                thenDoCalled = true;
+                return Task.CompletedTask;
+            })
+            .Then(num =>
+            {
+                thenCalled = true;
+                return num.ToString();
+            });
+
+        // Assert
+        thenDoCalled.Should().BeFalse();
+        thenCalled.Should().BeFalse();
+        result.IsError.Should().BeTrue();
+        result.FirstError.Type.Should().Be(ErrorType.Validation);
+        result.FirstError.Description.Should().Be("6 is too big");
+    }
+
+    [Fact]
     public async Task CallingThenEnsureAsyncExtensionMethod_WhenEnsureSucceeds_ShouldReturnOriginalValue()
     {
         // Arrange

--- a/tests/ErrorOr/ErrorOr.ThenEnsureAsyncTests.cs
+++ b/tests/ErrorOr/ErrorOr.ThenEnsureAsyncTests.cs
@@ -1,0 +1,74 @@
+using ErrorOr;
+using FluentAssertions;
+
+namespace Tests;
+
+public class ThenEnsureAsyncTests
+{
+    [Fact]
+    public async Task CallingThenEnsureAsync_WhenEnsureSucceeds_ShouldReturnOriginalValue()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = 5;
+
+        // Act
+        ErrorOr<int> result = await errorOrInt
+            .ThenEnsureAsync(num => Task.FromResult<ErrorOr<int>>(num > 3 ? num + 10 : Error.Validation()));
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task CallingThenEnsureAsync_WhenEnsureReturnsError_ShouldReturnEnsureErrors()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = 5;
+
+        // Act
+        ErrorOr<int> result = await errorOrInt
+            .ThenEnsureAsync(num => Task.FromResult<ErrorOr<int>>(num > 3 ? Error.Validation(description: $"{num} is too big") : num));
+
+        // Assert
+        result.IsError.Should().BeTrue();
+        result.FirstError.Type.Should().Be(ErrorType.Validation);
+        result.FirstError.Description.Should().Be("5 is too big");
+    }
+
+    [Fact]
+    public async Task CallingThenEnsureAsync_WhenIsError_ShouldNotInvokeEnsure()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = Error.NotFound();
+        bool called = false;
+
+        // Act
+        ErrorOr<int> result = await errorOrInt
+            .ThenEnsureAsync(num =>
+            {
+                called = true;
+                return Task.FromResult<ErrorOr<int>>(num);
+            });
+
+        // Assert
+        called.Should().BeFalse();
+        result.IsError.Should().BeTrue();
+        result.FirstError.Type.Should().Be(ErrorType.NotFound);
+    }
+
+    [Fact]
+    public async Task CallingThenEnsureAsyncExtensionMethod_WhenEnsureSucceeds_ShouldReturnOriginalValue()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = 5;
+
+        // Act
+        ErrorOr<int> result = await Task.FromResult(errorOrInt)
+            .ThenEnsureAsync(num => Task.FromResult<ErrorOr<int>>(num > 3 ? num + 100 : Error.Validation()));
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.Should().Be(5);
+    }
+}

--- a/tests/ErrorOr/ErrorOr.ThenEnsureTests.cs
+++ b/tests/ErrorOr/ErrorOr.ThenEnsureTests.cs
@@ -58,6 +58,53 @@ public class ThenEnsureTests
     }
 
     [Fact]
+    public void CallingThenEnsureAfterThen_WhenEnsureSucceeds_ShouldContinueChainWithOriginalValue()
+    {
+        // Arrange
+        ErrorOr<string> errorOrString = "5";
+        int valueFromThenDo = 0;
+
+        // Act
+        ErrorOr<string> result = errorOrString
+            .Then(Convert.ToInt)
+            .ThenEnsure(num => num > 3 ? num + 10 : Error.Validation())
+            .ThenDo(num => valueFromThenDo = num)
+            .Then(Convert.ToString);
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.Should().Be("5");
+        valueFromThenDo.Should().Be(5);
+    }
+
+    [Fact]
+    public void CallingThenEnsureAfterThen_WhenEnsureReturnsError_ShouldNotInvokeLaterChain()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = 5;
+        bool thenDoCalled = false;
+        bool thenCalled = false;
+
+        // Act
+        ErrorOr<int> result = errorOrInt
+            .Then(num => num + 1)
+            .ThenEnsure(num => num > 3 ? Error.Validation(description: $"{num} is too big") : num)
+            .ThenDo(_ => thenDoCalled = true)
+            .Then(num =>
+            {
+                thenCalled = true;
+                return num * 2;
+            });
+
+        // Assert
+        thenDoCalled.Should().BeFalse();
+        thenCalled.Should().BeFalse();
+        result.IsError.Should().BeTrue();
+        result.FirstError.Type.Should().Be(ErrorType.Validation);
+        result.FirstError.Description.Should().Be("6 is too big");
+    }
+
+    [Fact]
     public async Task CallingThenEnsureExtensionMethod_WhenEnsureSucceeds_ShouldReturnOriginalValue()
     {
         // Arrange

--- a/tests/ErrorOr/ErrorOr.ThenEnsureTests.cs
+++ b/tests/ErrorOr/ErrorOr.ThenEnsureTests.cs
@@ -1,0 +1,74 @@
+using ErrorOr;
+using FluentAssertions;
+
+namespace Tests;
+
+public class ThenEnsureTests
+{
+    [Fact]
+    public void CallingThenEnsure_WhenEnsureSucceeds_ShouldReturnOriginalValue()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = 5;
+
+        // Act
+        ErrorOr<int> result = errorOrInt
+            .ThenEnsure(num => num > 10 ? Error.Validation() : num + 10);
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.Should().Be(5);
+    }
+
+    [Fact]
+    public void CallingThenEnsure_WhenEnsureReturnsError_ShouldReturnEnsureErrors()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = 5;
+
+        // Act
+        ErrorOr<int> result = errorOrInt
+            .ThenEnsure(num => num > 3 ? Error.Validation(description: $"{num} is too big") : num);
+
+        // Assert
+        result.IsError.Should().BeTrue();
+        result.FirstError.Type.Should().Be(ErrorType.Validation);
+        result.FirstError.Description.Should().Be("5 is too big");
+    }
+
+    [Fact]
+    public void CallingThenEnsure_WhenIsError_ShouldNotInvokeEnsure()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = Error.NotFound();
+        bool called = false;
+
+        // Act
+        ErrorOr<int> result = errorOrInt
+            .ThenEnsure(num =>
+            {
+                called = true;
+                return num;
+            });
+
+        // Assert
+        called.Should().BeFalse();
+        result.IsError.Should().BeTrue();
+        result.FirstError.Type.Should().Be(ErrorType.NotFound);
+    }
+
+    [Fact]
+    public async Task CallingThenEnsureExtensionMethod_WhenEnsureSucceeds_ShouldReturnOriginalValue()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = 5;
+
+        // Act
+        ErrorOr<int> result = await Task.FromResult(errorOrInt)
+            .ThenEnsure(num => num > 3 ? num + 100 : Error.Validation());
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.Should().Be(5);
+    }
+}


### PR DESCRIPTION
Currently, there is no way to "capture" errors from ErrorOr side-effecting functions. There is a **tap** operation in the form of `ThenDo`. However, `TheDo` expects an action and completely disposes of a result. There is a gap where one cannot perform a side-effecting function and capture an error wile disregarding a success result.

Below is an example of how `ThenEnsure` works in consumers.

```csharp
// db.Save returns an ErrorOr<Success>

var weatherResult = api.GetWeather(userId).ThenEnsure(db.Save));
```

As another example where the consumer needs to be informed of an error that could occur in some cloud service but the success result of what the could service returns is not important to the consumer.

```csharp
// cloud.CreateExternalIdenties returns `ErrorOr<Identies>`

ErrorOr<User> EnsureUser(string userId) =>
    db.GetUser(userId).ThenEnsure(cloud.CreateExternalIdenties);
```

The proposal introduces a new "ensure" step to the `ErrorOr` monadic pipeline, allowing developers to add validation and error-checking logic to chained operations. The new `ThenEnsure` and `ThenEnsureAsync` methods (and their extension counterparts) enable consumers to return errors when a condition fails, while preserving the original value if no errors are returned. Documentation and tests have been updated to cover these additions.

Additions to the ErrorOr pipeline:

* Added `ThenEnsure` and `ThenEnsureAsync` methods to `ErrorOr<TValue>`, allowing validation or error-checking functions to be injected into the pipeline. These methods return errors if the provided function does, or preserve the original value otherwise. [[1]](diffhunk://#diff-318f23c6fcdf7bf0dfeefa24c87cf2ecd37918bc48319b027f71d8948ae7c459R38-R55) [[2]](diffhunk://#diff-318f23c6fcdf7bf0dfeefa24c87cf2ecd37918bc48319b027f71d8948ae7c459R105-R122)
* Added extension methods `ThenEnsure` and `ThenEnsureAsync` for `Task<ErrorOr<TValue>>`, supporting async pipelines with ensure steps. [[1]](diffhunk://#diff-682510a67b75f9c077ef80c27c1b3173299305d7ba404ae7031f335ec5b23b00R49-R63) [[2]](diffhunk://#diff-682510a67b75f9c077ef80c27c1b3173299305d7ba404ae7031f335ec5b23b00R107-R121)

Documentation updates:

* Updated `README.md` to document the new `ThenEnsure` and `ThenEnsureAsync` methods, including usage examples and revised mixing section. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L53-R54) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L509-R543)

Testing:

* Added unit tests for `ThenEnsure` in `tests/ErrorOr/ErrorOr.ThenEnsureTests.cs`, covering successful validation, error cases, and ensuring the function is not called when already in an error state.
* Added unit tests for `ThenEnsureAsync` in `tests/ErrorOr/ErrorOr.ThenEnsureAsyncTests.cs`, covering async validation, error cases, and extension method scenarios.