### PR TITLE
Modernize NuGet publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,4 +53,4 @@ jobs:
       - name: Pack
         run: dotnet pack src/ErrorOr.csproj -c Release -p:Version=${{ steps.version.outputs.version }} -o artifacts
       - name: Publish to NuGet
-        run: dotnet nuget push "artifacts/*.nupkg" --api-key "${{ secrets.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push "artifacts/*.nupkg" --api-key "${{ secrets.ERROR_OR_NUGET_SECRET }}" --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,24 +1,56 @@
-name: publish ErrorOr to nuget
-on:
-    workflow_dispatch:
-    push:
-        branches:
-            - main # Default release branch
-        paths:
-            - "src/**"
-jobs:
-    publish:
-        name: build, pack & publish
-        runs-on: windows-latest
-        steps:
-            - uses: actions/checkout@v2
-            - name: Setup dotnet
-              uses: actions/setup-dotnet@v1
-              with:
-                  dotnet-version: 8.0.100
+name: Publish to NuGet
 
-            # Publish
-            - name: Package
-              run: dotnet pack -c Release src/ErrorOr.csproj
-            - name: Publish
-              run: dotnet nuget push .\artifacts\*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Package version (without leading v, e.g. 3.0.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      - run: dotnet restore
+      - run: dotnet build -c Release --no-restore
+      - run: dotnet test -c Release --no-restore --verbosity normal
+
+  publish:
+    name: Pack and publish
+    needs: test
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      - name: Resolve version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION="${GITHUB_REF_NAME#v}"
+          fi
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not resolve a version" && exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $VERSION"
+      - name: Pack
+        run: dotnet pack src/ErrorOr.csproj -c Release -p:Version=${{ steps.version.outputs.version }} -o artifacts
+      - name: Publish to NuGet
+        run: dotnet nuget push "artifacts/*.nupkg" --api-key "${{ secrets.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json

--- a/src/ErrorOr.csproj
+++ b/src/ErrorOr.csproj
@@ -7,15 +7,15 @@
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>ErrorOr</PackageId>
-    <Version>2.0.1</Version>
+    <Version>0.0.0-dev</Version>
     <Authors>Amichai Mantinband</Authors>
     <PackageIcon>icon-square.png</PackageIcon>
     <PackageTags>Result,Results,ErrorOr,Error,Handling</PackageTags>
     <Description>A simple, fluent discriminated union of an error or a result.</Description>
-    <PackageProjectUrl>https://github.com/amantinband/error-or</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/error-or/error-or</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <licenses>https://opensource.org/licenses/MIT</licenses>
-    <RepositoryUrl>https://github.com/amantinband/error-or</RepositoryUrl>
+    <RepositoryUrl>https://github.com/error-or/error-or</RepositoryUrl>
     <PackageOutputPath>../artifacts/</PackageOutputPath>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- Tag-driven publish: pushing a `v*` tag triggers build + test + (gated) publish. No more auto-shipping on every commit to `main`.
- Adds an approval gate via a GitHub Environment named `production` (required reviewer must approve each release).
- Removes `--skip-duplicate` so duplicate version pushes fail loudly.
- Moves the version source out of `ErrorOr.csproj` (now `0.0.0-dev` placeholder); CI injects the real version from the tag via `-p:Version=`.
- Updates `PackageProjectUrl` / `RepositoryUrl` to the new `error-or/error-or` org.
- Modernizes the workflow: `ubuntu-latest`, `actions/checkout@v4`, `actions/setup-dotnet@v4`, runs the test suite before pack/publish.

## Setup needed before merging
1. Create a GitHub Environment named `production` on this repo (Settings → Environments → New environment).
2. Add required reviewers to that environment (the people who must click "approve" before each release).
3. Add the `ERROR_OR_NUGET_SECRET` secret to the `production` environment (NOT to repo secrets, environment-scoped is tighter).
4. After merge, optionally add a tag protection rule for `v*` so only admins can push release tags.

## Releasing after merge
```
git tag v3.0.0
git push --tags
```
Workflow runs build + tests, then waits at the publish step for environment approval, then ships to NuGet.

## Test plan
- [ ] After merge, set up the `production` environment with `ERROR_OR_NUGET_SECRET` and required reviewers.
- [ ] Push a test tag like `v2.0.2` (or whatever the next real version is) and confirm the workflow gates on approval.
- [ ] Confirm the package lands on nuget.org with the correct version.
