### PR TITLE
Feature: Allow users to be able to get a string recording of the current state of the ErrorOr<> or IErrorOr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+nuget.config
+
 **/.ionide
 **/.vscode
 **/.vs

--- a/README.md
+++ b/README.md
@@ -642,6 +642,37 @@ void Log(IErrorOr result)
 // ]
 ```
 
+When you have a concrete `ErrorOr<TValue>` reference, `ToString()` produces the same JSON output as `GetRecording()`, so it works naturally in string interpolation or anywhere a string is expected:
+
+```cs
+ErrorOr<User> result = GetUser(id);
+
+// Explicit call
+Console.WriteLine(result.ToString());
+
+// Implicit — string interpolation calls ToString() automatically
+logger.LogInformation("Result: {Result}", result);
+Console.WriteLine($"Outcome: {result}");
+
+// Value state:
+// {
+//   "Name": "Alice",
+//   "MiddleName": null,
+//   "Age": 30
+// }
+
+// Error state:
+// [
+//   {
+//     "Code": "User.NotFound",
+//     "Description": "User was not found.",
+//     "Type": "NotFound",
+//     "NumericType": 3,
+//     "Metadata": null
+//   }
+// ]
+```
+
 # Error Types
 
 Each `Error` instance has a `Type` property, which is an enum value that represents the type of the error.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@
     - [`ElseAsync`](#elseasync)
     - [`ElseDo` and `ElseDoAsync`](#elsedo-and-elsedoasync)
 - [Mixing Features (`Then`, `FailIf`, `Else`, `Switch`, `Match`)](#mixing-features-then-failif-else-switch-match)
+- [Recording Outcomes](#recording-outcomes)
 - [Error Types](#error-types)
   - [Built in error types](#built-in-error-types)
   - [Custom error types](#custom-error-types)
@@ -606,6 +607,39 @@ ErrorOr<string> foo = await errorOrInt
       .MatchFirst(
           value => value,
           firstError => $"An error occurred: {firstError.Description}");
+```
+
+# Recording Outcomes
+
+When working in cross-cutting concerns such as logging, auditing, or middleware pipelines, you may hold a reference to `IErrorOr` without knowing the concrete `TValue` type. The `IRecordable` interface provides a way to obtain a JSON representation of the current state in these scenarios.
+
+Because `IErrorOr` inherits from `IRecordable`, `GetRecording()` is available directly on any `IErrorOr` reference — no cast required.
+
+`GetRecording()` always returns safely — when the state is a value it returns a JSON object; when the state is errors it returns a JSON array of those errors. The output is indented, enums are serialized as strings, and null properties are always included:
+
+```cs
+void Log(IErrorOr result)
+{
+    Console.WriteLine(result.GetRecording());
+}
+
+// Value state:
+// {
+//   "Name": "Alice",
+//   "MiddleName": null,
+//   "Age": 30
+// }
+
+// Error state:
+// [
+//   {
+//     "Code": "User.NotFound",
+//     "Description": "User was not found.",
+//     "Type": "NotFound",
+//     "NumericType": 3,
+//     "Metadata": null
+//   }
+// ]
 ```
 
 # Error Types

--- a/src/ErrorOr.csproj
+++ b/src/ErrorOr.csproj
@@ -26,7 +26,16 @@
     <AdditionalFiles Include="Stylecop.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference
+      Include="Microsoft.Bcl.HashCode"
+      Version="1.1.1"
+      Condition="'$(TargetFramework)' == 'netstandard2.0'"
+    />
+    <PackageReference
+      Include="System.Text.Json"
+      Version="8.0.5"
+      Condition="'$(TargetFramework)' == 'netstandard2.0'"
+    />
     <PackageReference Include="Nullable" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/ErrorOr/ErrorOr.Recordable.cs
+++ b/src/ErrorOr/ErrorOr.Recordable.cs
@@ -1,11 +1,31 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace ErrorOr;
 
 public readonly partial record struct ErrorOr<TValue>
 {
     /// <inheritdoc/>
-    public string GetRecording() => IsError
-        ? JsonSerializer.Serialize(Errors, RecordableDefaults.JsonOptions)
-        : JsonSerializer.Serialize(Value, RecordableDefaults.JsonOptions);
+    public string GetRecording() => GetRecording(RecordableDefaults.JsonOptions);
+
+    /// <inheritdoc/>
+    public string GetRecording(JsonSerializerOptions options)
+    {
+        if (IsError)
+        {
+            return JsonSerializer.Serialize(Errors, options);
+        }
+
+        return JsonSerializer.Serialize(Value, options);
+    }
+}
+
+internal static class RecordableDefaults
+{
+    internal static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter() },
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
 }

--- a/src/ErrorOr/ErrorOr.Recordable.cs
+++ b/src/ErrorOr/ErrorOr.Recordable.cs
@@ -1,0 +1,11 @@
+using System.Text.Json;
+
+namespace ErrorOr;
+
+public readonly partial record struct ErrorOr<TValue>
+{
+    /// <inheritdoc/>
+    public string GetRecording() => IsError
+        ? JsonSerializer.Serialize(Errors, RecordableDefaults.JsonOptions)
+        : JsonSerializer.Serialize(Value, RecordableDefaults.JsonOptions);
+}

--- a/src/ErrorOr/ErrorOr.cs
+++ b/src/ErrorOr/ErrorOr.cs
@@ -113,8 +113,11 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// Creates an <see cref="ErrorOr{TValue}"/> from a list of errors.
     /// </summary>
     [Obsolete("ErrorOrFactory.From<TValue>(errors) should be used instead.")]
-    public static ErrorOr<TValue> From(List<Error> errors)
-    {
-        return errors;
-    }
+    public static ErrorOr<TValue> From(List<Error> errors) => errors;
+
+    /// <summary>
+    /// Returns a JSON representation of the current <see cref="ErrorOr{TValue}"/> instance.
+    /// </summary>
+    /// <returns>A JSON string representation of the current <see cref="ErrorOr{TValue}"/> instance.</returns>
+    public override string ToString() => GetRecording();
 }

--- a/src/ErrorOr/IErrorOr.cs
+++ b/src/ErrorOr/IErrorOr.cs
@@ -18,7 +18,7 @@ public interface IErrorOr<out TValue> : IErrorOr
 /// This interface is intended for use when the underlying type of the <see cref="ErrorOr"/> object is unknown.
 /// </remarks>
 [CollectionBuilder(typeof(CollectionExpression), nameof(CollectionExpression.CreateIErrorOr))]
-public interface IErrorOr
+public interface IErrorOr : IRecordable
 {
     /// <summary>
     /// Gets the list of errors.

--- a/src/ErrorOr/IRecordable.cs
+++ b/src/ErrorOr/IRecordable.cs
@@ -1,0 +1,37 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ErrorOr;
+
+/// <summary>
+/// Interface for producing a loggable string representation of an <see cref="ErrorOr{TValue}"/> value
+/// without knowing its concrete type.
+/// </summary>
+/// <remarks>
+/// Intended for use in cross-cutting concerns such as logging and auditing where the concrete
+/// type of the value is unknown at the call site.
+/// </remarks>
+public interface IRecordable
+{
+    /// <summary>
+    /// Returns a JSON representation of the current state.
+    /// </summary>
+    /// <returns>
+    /// When <see cref="IErrorOr.IsError"/> is <c>false</c>, returns a JSON representation of the value.
+    /// When <see cref="IErrorOr.IsError"/> is <c>true</c>, returns a JSON array of the recorded errors.
+    /// </returns>
+    string GetRecording();
+}
+
+internal static class RecordableDefaults
+{
+    internal static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+        Converters =
+        {
+            new JsonStringEnumConverter(),
+        },
+    };
+}

--- a/src/ErrorOr/IRecordable.cs
+++ b/src/ErrorOr/IRecordable.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace ErrorOr;
 
@@ -21,17 +20,14 @@ public interface IRecordable
     /// When <see cref="IErrorOr.IsError"/> is <c>true</c>, returns a JSON array of the recorded errors.
     /// </returns>
     string GetRecording();
-}
 
-internal static class RecordableDefaults
-{
-    internal static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        WriteIndented = true,
-        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
-        Converters =
-        {
-            new JsonStringEnumConverter(),
-        },
-    };
+    /// <summary>
+    /// Returns a JSON representation of the current state using the specified <see cref="JsonSerializerOptions"/>.
+    /// </summary>
+    /// <param name="options">The <see cref="JsonSerializerOptions"/> to use for serialization.</param>
+    /// <returns>
+    /// When <see cref="IErrorOr.IsError"/> is <c>false</c>, returns a JSON representation of the value.
+    /// When <see cref="IErrorOr.IsError"/> is <c>true</c>, returns a JSON array of the recorded errors.
+    /// </returns>
+    string GetRecording(JsonSerializerOptions options);
 }

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -23,6 +23,53 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
+    public void CreateFromValue_WhenAccessingValue_ViaStronglyTypedInterface_ShouldReturnValue()
+    {
+        // Arrange
+        IEnumerable<string> value = ["value"];
+
+        // Act
+#pragma warning disable CA1859 // Use concrete types when possible for improved performance
+        IErrorOr<IEnumerable<string>> errorOrValue = ErrorOrFactory.From(value);
+#pragma warning restore CA1859 // Use concrete types when possible for improved performance
+
+        // Assert
+        errorOrValue.IsError.Should().BeFalse();
+        errorOrValue.Value.Should().BeSameAs(value);
+    }
+
+    [Fact]
+    public void CreateFromValue_WhenAccessingValue_ViaIRecordable_ShouldReturnJson()
+    {
+        // Arrange
+        IEnumerable<string> value = ["value"];
+
+        // Act
+#pragma warning disable CA1859 // Use concrete types when possible for improved performance
+        IRecordable errorOrValue = ErrorOrFactory.From(value);
+#pragma warning restore CA1859 // Use concrete types when possible for improved performance
+
+        // Assert
+        errorOrValue.GetRecording().Should().Be(System.Text.Json.JsonSerializer.Serialize(value, new System.Text.Json.JsonSerializerOptions { WriteIndented = true, IncludeFields = true }));
+    }
+
+    [Fact]
+    public void CreateFromError_WhenAccessingValue_ViaIRecordable_ShouldReturnJsonErrors()
+    {
+        // Arrange
+        var error = Error.Unexpected();
+#pragma warning disable CA1859 // Use concrete types when possible for improved performance
+        IRecordable errorOrValue = (ErrorOr<string>)error;
+#pragma warning restore CA1859 // Use concrete types when possible for improved performance
+
+        // Act
+        var recording = errorOrValue.GetRecording();
+
+        // Assert
+        recording.Should().Be(System.Text.Json.JsonSerializer.Serialize(new[] { error }, new System.Text.Json.JsonSerializerOptions { WriteIndented = true, IncludeFields = true, Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() } }));
+    }
+
+    [Fact]
     public void CreateFromValue_WhenAccessingErrors_ShouldThrow()
     {
         // Arrange
@@ -144,7 +191,7 @@ public class ErrorOrInstantiationTests
         var act = () => errorOrPerson.Value;
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
+        act.Should().ThrowExactly<InvalidOperationException>()
            .And.Message.Should().Be("The Value property cannot be accessed when errors have been recorded. Check IsError before accessing Value.");
     }
 
@@ -273,7 +320,7 @@ public class ErrorOrInstantiationTests
         var act = () => errorOrPerson.Value;
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
+        act.Should().ThrowExactly<InvalidOperationException>()
            .And.Message.Should().Be("The Value property cannot be accessed when errors have been recorded. Check IsError before accessing Value.");
     }
 

--- a/tests/ErrorOr/ErrorOr.RecordableTests.cs
+++ b/tests/ErrorOr/ErrorOr.RecordableTests.cs
@@ -1,0 +1,155 @@
+namespace Tests;
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ErrorOr;
+using FluentAssertions;
+
+public class ErrorOrRecordableTests
+{
+    [Fact]
+    public void GetRecording_WhenTValueIsRecordClass_ShouldReturnJson()
+    {
+        // Arrange
+        var person = new PersonRecord(
+            "Alice",
+            null,
+            30,
+            PersonStatus.Active,
+            new AddressRecord("123 Main St", "Springfield", null),
+            ["Developer", "Admin"]);
+
+        IRecordable errorOr = ErrorOrFactory.From(person);
+
+        // Act
+        var recording = errorOr.GetRecording();
+
+        // Assert
+        recording.Should().Be(JsonSerializer.Serialize(person, JsonOptions));
+    }
+
+    [Fact]
+    public void GetRecording_WhenTValueIsRecordStruct_ShouldReturnJson()
+    {
+        // Arrange
+        var person = new PersonRecordStruct(
+            "Alice",
+            null,
+            30,
+            PersonStatus.Active,
+            [new AddressRecord("123 Main St", "Springfield", null), new AddressRecord("456 Oak Ave", "Shelbyville", "62565")]);
+
+        IRecordable errorOr = ErrorOrFactory.From(person);
+
+        // Act
+        var recording = errorOr.GetRecording();
+
+        // Assert
+        recording.Should().Be(JsonSerializer.Serialize(person, JsonOptions));
+    }
+
+    [Fact]
+    public void GetRecording_WhenTValueIsPlainClass_ShouldReturnJson()
+    {
+        // Arrange
+        var person = new PersonClass(
+            "Alice",
+            null,
+            30,
+            PersonStatus.Active,
+            [new AddressRecord("123 Main St", "Springfield", null), new AddressRecord("456 Oak Ave", "Shelbyville", "62565")]);
+
+        IRecordable errorOr = ErrorOrFactory.From(person);
+
+        // Act
+        var recording = errorOr.GetRecording();
+
+        // Assert
+        recording.Should().Be(JsonSerializer.Serialize(person, JsonOptions));
+    }
+
+    [Fact]
+    public void GetRecording_WhenTValueIsPlainStruct_ShouldReturnJson()
+    {
+        // Arrange
+        var person = new PersonStruct(
+            "Alice",
+            null,
+            PersonStatus.Active,
+            [new AddressRecord("123 Main St", "Springfield", null)]);
+
+        IRecordable errorOr = ErrorOrFactory.From(person);
+
+        // Act
+        var recording = errorOr.GetRecording();
+
+        // Assert
+        recording.Should().Be(JsonSerializer.Serialize(person, JsonOptions));
+    }
+
+    [Fact]
+    public void GetRecording_WhenIsError_ShouldReturnJsonErrors()
+    {
+        // Arrange
+        var error = Error.Unexpected();
+
+        IRecordable errorOr = (ErrorOr<PersonRecord>)error;
+
+        // Act
+        var recording = errorOr.GetRecording();
+
+        // Assert
+        recording.Should().Be(JsonSerializer.Serialize(new[] { error }, JsonOptions));
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+        Converters =
+        {
+            new JsonStringEnumConverter(),
+        },
+    };
+
+    private enum PersonStatus
+    {
+        Active,
+        Inactive,
+        Suspended,
+    }
+
+    private record AddressRecord(string Street, string City, string? PostalCode);
+
+    private record PersonRecord(
+        string Name,
+        string? MiddleName,
+        int Age,
+        PersonStatus Status,
+        AddressRecord? Address,
+        List<string>? Tags);
+
+    private readonly record struct PersonRecordStruct(
+        string Name,
+        string? MiddleName,
+        int Age,
+        PersonStatus Status,
+        List<AddressRecord>? Addresses);
+
+    private class PersonClass(string name, string? middleName, int age, PersonStatus status, List<AddressRecord>? addresses)
+    {
+        public string Name { get; } = name;
+        public string? MiddleName { get; } = middleName;
+        public int Age { get; } = age;
+        public PersonStatus Status { get; } = status;
+        public List<AddressRecord>? Addresses { get; } = addresses;
+    }
+
+    private readonly struct PersonStruct(string name, string? middleName, PersonStatus status, List<AddressRecord>? addresses)
+    {
+        public string Name { get; } = name;
+        public string? MiddleName { get; } = middleName;
+        public PersonStatus Status { get; } = status;
+        public List<AddressRecord>? Addresses { get; } = addresses;
+    }
+}

--- a/tests/ErrorOr/ErrorOr.RecordableTests.cs
+++ b/tests/ErrorOr/ErrorOr.RecordableTests.cs
@@ -102,6 +102,42 @@ public class ErrorOrRecordableTests
         recording.Should().Be(JsonSerializer.Serialize(new[] { error }, JsonOptions));
     }
 
+    [Fact]
+    public void ToString_WhenTValueIsValue_ShouldReturnJson()
+    {
+        // Arrange
+        var person = new PersonRecord(
+            "Alice",
+            null,
+            30,
+            PersonStatus.Active,
+            new AddressRecord("123 Main St", "Springfield", null),
+            ["Developer", "Admin"]);
+
+        ErrorOr<PersonRecord> errorOr = ErrorOrFactory.From(person);
+
+        // Act
+        var result = errorOr.ToString();
+
+        // Assert
+        result.Should().Be(JsonSerializer.Serialize(person, JsonOptions));
+    }
+
+    [Fact]
+    public void ToString_WhenIsError_ShouldReturnJsonErrors()
+    {
+        // Arrange
+        var error = Error.Unexpected();
+
+        ErrorOr<PersonRecord> errorOr = error;
+
+        // Act
+        var result = errorOr.ToString();
+
+        // Assert
+        result.Should().Be(JsonSerializer.Serialize(new[] { error }, JsonOptions));
+    }
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         WriteIndented = true,

--- a/tests/ErrorOr/ErrorOr.RecordableTests.cs
+++ b/tests/ErrorOr/ErrorOr.RecordableTests.cs
@@ -138,6 +138,185 @@ public class ErrorOrRecordableTests
         result.Should().Be(JsonSerializer.Serialize(new[] { error }, JsonOptions));
     }
 
+    [Fact]
+    public void GetRecording_WithCompactJsonOptions_ShouldReturnCompactJson()
+    {
+        // Arrange
+        var person = new PersonRecord(
+            "Bob",
+            "James",
+            25,
+            PersonStatus.Active,
+            new AddressRecord("456 Elm St", "Springfield", null),
+            ["Developer"]);
+
+        var compactOptions = new JsonSerializerOptions
+        {
+            WriteIndented = false,
+            DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+            Converters = { new JsonStringEnumConverter() },
+        };
+
+        ErrorOr<PersonRecord> errorOr = ErrorOrFactory.From(person);
+
+        // Act
+        var recording = errorOr.GetRecording(compactOptions);
+
+        // Assert
+        recording.Should().Be(JsonSerializer.Serialize(person, compactOptions));
+        recording.Should().NotContain("\n");
+        recording.Should().NotContain("  ");
+    }
+
+    [Fact]
+    public void GetRecording_WithIgnoreNullValuesOption_ShouldOmitNullProperties()
+    {
+        // Arrange
+        var person = new PersonRecord(
+            "Charlie",
+            null,
+            35,
+            PersonStatus.Inactive,
+            null,
+            null);
+
+        var ignoreNullOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            Converters = { new JsonStringEnumConverter() },
+        };
+
+        ErrorOr<PersonRecord> errorOr = ErrorOrFactory.From(person);
+
+        // Act
+        var recording = errorOr.GetRecording(ignoreNullOptions);
+
+        // Assert
+        recording.Should().Be(JsonSerializer.Serialize(person, ignoreNullOptions));
+        recording.Should().NotContain("\"middleName\"");
+        recording.Should().NotContain("\"address\"");
+        recording.Should().NotContain("\"tags\"");
+    }
+
+    [Fact]
+    public void GetRecording_WithPropertyNamingPolicy_ShouldUseCamelCase()
+    {
+        // Arrange
+        var person = new PersonRecord(
+            "Diana",
+            "Marie",
+            28,
+            PersonStatus.Active,
+            new AddressRecord("789 Oak Ave", "Capital City", "12345"),
+            ["Engineer", "Lead"]);
+
+        var camelCaseOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+            Converters = { new JsonStringEnumConverter() },
+        };
+
+        ErrorOr<PersonRecord> errorOr = ErrorOrFactory.From(person);
+
+        // Act
+        var recording = errorOr.GetRecording(camelCaseOptions);
+
+        // Assert
+        recording.Should().Be(JsonSerializer.Serialize(person, camelCaseOptions));
+        recording.Should().Contain("\"name\"");
+        recording.Should().Contain("\"middleName\"");
+        recording.Should().Contain("\"age\"");
+        recording.Should().NotContain("\"Name\"");
+        recording.Should().NotContain("\"MiddleName\"");
+    }
+
+    [Fact]
+    public void GetRecording_WithCustomOptions_WhenError_ShouldRespectOptions()
+    {
+        // Arrange
+        var error = Error.Unexpected();
+        var compactOptions = new JsonSerializerOptions
+        {
+            WriteIndented = false,
+            DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+            Converters = { new JsonStringEnumConverter() },
+        };
+
+        ErrorOr<PersonRecord> errorOr = error;
+
+        // Act
+        var recording = errorOr.GetRecording(compactOptions);
+
+        // Assert
+        recording.Should().Be(JsonSerializer.Serialize(new[] { error }, compactOptions));
+        recording.Should().NotContain("\n");
+    }
+
+    [Fact]
+    public void GetRecording_CustomOptionsVsDefault_ShouldProduceDifferentOutput()
+    {
+        // Arrange
+        var person = new PersonRecord(
+            "Eve",
+            null,
+            40,
+            PersonStatus.Suspended,
+            new AddressRecord("321 Pine St", "Metropolis", null),
+            null);
+
+        var compactOptions = new JsonSerializerOptions
+        {
+            WriteIndented = false,
+            DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+            Converters = { new JsonStringEnumConverter() },
+        };
+
+        ErrorOr<PersonRecord> errorOr = ErrorOrFactory.From(person);
+
+        // Act
+        var defaultRecording = errorOr.GetRecording();
+        var customRecording = errorOr.GetRecording(compactOptions);
+
+        // Assert
+        defaultRecording.Should().NotBe(customRecording);
+        defaultRecording.Should().Contain("\n");
+        customRecording.Should().NotContain("\n");
+    }
+
+    [Fact]
+    public void GetRecording_WithInterfaceType_CustomOptions_ShouldReturnJson()
+    {
+        // Arrange
+        var person = new PersonRecord(
+            "Frank",
+            "Xavier",
+            32,
+            PersonStatus.Active,
+            new AddressRecord("654 Maple Dr", "Smallville", "54321"),
+            ["Manager"]);
+
+        var camelCaseOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+            Converters = { new JsonStringEnumConverter() },
+        };
+
+        IRecordable errorOr = ErrorOrFactory.From(person);
+
+        // Act
+        var recording = errorOr.GetRecording(camelCaseOptions);
+
+        // Assert
+        recording.Should().Be(JsonSerializer.Serialize(person, camelCaseOptions));
+        recording.Should().Contain("\"name\"");
+        recording.Should().Contain("\"status\"");
+    }
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         WriteIndented = true,


### PR DESCRIPTION
## Summary

Closes #121.

Adds an `IRecordable` interface with a `GetRecording()` method that returns a JSON representation of the current `ErrorOr<TValue>` state — either the serialized value or a JSON array of errors — without requiring knowledge of the concrete `TValue` type.

`IErrorOr` now inherits from `IRecordable`, so `GetRecording()` is available on any `IErrorOr` reference in cross-cutting concerns such as logging, auditing, and middleware pipelines without a cast.

`ErrorOr<TValue>.ToString()` is also overridden to delegate to `GetRecording()`, so the JSON representation is available implicitly in string interpolation and structured logging.

## Changes

- **`IRecordable`** (new) — interface defining `GetRecording()` and shared `RecordableDefaults.JsonOptions` (indented, enums as strings, nulls always included).
- **`IErrorOr`** — inherits `IRecordable`; `GetRecording()` is available on any weakly-typed `IErrorOr` reference with no cast.
- **`ErrorOr<TValue>.Recordable`** (new partial) — implements `GetRecording()`.
- **`ErrorOr<TValue>`** — overrides `ToString()` to return `GetRecording()`.
- **`README.md`** — new *Recording Outcomes* section documenting `GetRecording()` and `ToString()` with output examples.
- **`ErrorOr.RecordableTests`** (new) — full test coverage for `GetRecording()` and `ToString()` across record classes, record structs, plain classes, and plain structs, for both value and error states.

## Related

> **Note:** PR #136 by @zbyszekprasak addresses the same issue with a very similar approach (exposing a weakly-typed `Value` property). This PR takes a different angle — structured JSON output via `IRecordable` — rather than exposing the raw value. Reviewers may want to compare both before deciding which approach to merge.

## Test plan

- [x] `GetRecording()` returns correct JSON for record class, record struct, plain class, and plain struct values
- [x] `GetRecording()` returns a JSON array of errors when `IsError` is true
- [x] `ToString()` returns the same JSON as `GetRecording()` for a value state
- [x] `ToString()` returns the same JSON as `GetRecording()` for an error state
- [x] All 180 existing tests continue to pass