### PR TITLE
Require code-owner review on workflow file changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Workflow files have outsized security impact (they handle the NuGet API key
+# and gate releases), so changes to them require review from @amantinband.
+# Everything else is unowned and can be merged by any repo admin as usual.
+/.github/workflows/ @amantinband


### PR DESCRIPTION
## Summary
Adds a `CODEOWNERS` file requiring @amantinband review on any change under `.github/workflows/`. Other files stay unowned and can be merged by any repo admin without extra review.

## Why
Workflow files have outsized security impact: they handle `ERROR_OR_NUGET_SECRET` and gate releases. A subtle edit to `publish.yml` could quietly bypass the production environment approval, exfiltrate the NuGet key, or insert a malicious step. Code review on workflow changes specifically (not on every PR) is the lightest-weight way to defend against this.

This is not a comment on past PRs — recent workflow changes from @squadwuschel (e.g. #160, #171) have been responsible and improved security. This is just removing the structural ability to self-merge security-sensitive files going forward.

## Required followup after merge
CODEOWNERS only takes effect when **branch protection** requires reviews from code owners. After merging this PR:

1. Go to https://github.com/error-or/error-or/settings/branches → Add branch ruleset (or classic branch protection rule) for `main`.
2. Enable **Require a pull request before merging** → **Require review from Code Owners**.
3. Optionally also enable **Require status checks to pass** and select the `build` job from `build.yml` so PR tests are a hard gate.

Without that branch protection step, this CODEOWNERS file is purely advisory.

## Test plan
- [ ] Merge this PR
- [ ] Set up branch protection per above
- [ ] Open a test PR touching `.github/workflows/build.yml` and confirm it requires @amantinband review before merging
- [ ] Open a test PR touching unrelated source code and confirm it does NOT require @amantinband review
