### PR TITLE
Switch publish workflow to NuGet OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,9 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-dotnet@v5
@@ -52,5 +55,10 @@ jobs:
           echo "Resolved version: $VERSION"
       - name: Pack
         run: dotnet pack src/ErrorOr.csproj -c Release -p:Version=${{ steps.version.outputs.version }} -o artifacts
+      - name: NuGet login (OIDC -> short-lived API key)
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: ${{ secrets.NUGET_USER }}
       - name: Publish to NuGet
-        run: dotnet nuget push "artifacts/*.nupkg" --api-key "${{ secrets.ERROR_OR_NUGET_SECRET }}" --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push "artifacts/*.nupkg" --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
## Summary
Replaces the long-lived `ERROR_OR_NUGET_SECRET` API key with NuGet's OIDC trusted publishing flow. Suggested by @squadwuschel in #171.

## What changes
- Adds `permissions: id-token: write` to the publish job so GitHub Actions can mint an OIDC token.
- Adds a `NuGet/login@v1` step between Pack and Publish that exchanges the OIDC token for a short-lived (1-hour) NuGet API key.
- Push step uses `${{ steps.nuget-login.outputs.NUGET_API_KEY }}` instead of `secrets.ERROR_OR_NUGET_SECRET`.

## Why
- No long-lived NuGet API key in the env, so no annual rotation chore and no leak risk.
- `NUGET_USER` (just the nuget.org profile name, not a credential) replaces the API key as the only required env value.
- The trust policy on nuget.org pins publishing to this repo + this workflow + the `production` environment. Even a compromised maintainer account can't push ErrorOr from a different workflow.
- The production environment approval gate still applies. The OIDC token isn't issued until the publish job actually starts, which only happens after the gate clears.

## Setup that's already in place
- ✅ Trusted publisher policy created on nuget.org (Repository Owner: `error-or`, Repository: `error-or`, Workflow File: `publish.yml`, Environment: `production`)
- ✅ `NUGET_USER` secret added to the `production` environment

## Test plan
- [ ] Merge this PR
- [ ] Push a test tag (e.g. `v2.1.1-rc.3`) to verify the OIDC exchange works end-to-end
- [ ] Approve the deployment when prompted
- [ ] Verify package lands at https://www.nuget.org/packages/ErrorOr/

## Cleanup (separate followup, after one successful OIDC publish)
- Remove `ERROR_OR_NUGET_SECRET` from the `production` environment (no longer used)
- Revoke the corresponding API key on https://www.nuget.org/account/apikeys
- Note: `unlist.yml` still uses `ERROR_OR_NUGET_SECRET`. Open question whether the OIDC-issued temp keys have unlist scope on nuget.org. Worth verifying before removing the long-lived key.
