### PR TITLE
Migrate unlist workflow to NuGet OIDC

### DIFF
--- a/.github/workflows/unlist.yml
+++ b/.github/workflows/unlist.yml
@@ -4,7 +4,7 @@ on:
     workflow_dispatch:
         inputs:
             version:
-                description: 'Version to unlist from NuGet feed (z.B. 1.2.3)'
+                description: 'Version to unlist from NuGet feed (e.g. 1.2.3)'
                 required: true
                 type: string
 
@@ -12,12 +12,25 @@ jobs:
     unlist:
         runs-on: ubuntu-latest
         environment: production
+        permissions:
+            id-token: write
+            contents: read
         steps:
+            - uses: actions/setup-dotnet@v5
+              with:
+                  dotnet-version: 8.0.x
+            - name: NuGet login (OIDC -> short-lived API key)
+              uses: NuGet/login@v1
+              id: nuget-login
+              with:
+                  user: ${{ secrets.NUGET_USER }}
             - name: Unlist from NuGet
+              env:
+                  VERSION: ${{ github.event.inputs.version }}
               run: |
                   dotnet nuget delete \
                     ErrorOr \
-                    "${{ github.event.inputs.version }}" \
-                    --api-key "${{ secrets.ERROR_OR_NUGET_SECRET }}" \
+                    "$VERSION" \
+                    --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
                     --source https://api.nuget.org/v3/index.json \
                     --non-interactive


### PR DESCRIPTION
## Summary
Migrates `unlist.yml` to NuGet OIDC trusted publishing, mirroring the `publish.yml` migration in #173. Also applies the env-var binding pattern for the version input (template injection defense).

## Why
- The previous setup had two problems: it depended on the long-lived `ERROR_OR_NUGET_SECRET` (which @squadwuschel reported didn't have unlist permission anyway), and it interpolated user input directly into a shell script.
- This PR aims to fix both. Whether OIDC-issued short-lived keys actually grant unlist scope on nuget.org is **not documented** — the official docs only describe the publish flow. This PR is the empirical test.

## Setup that's already in place
- ✅ Trust policy on nuget.org for `unlist.yml` workflow (added by @amantinband)
- ✅ `NUGET_USER` already on the `production` environment

## Test plan
- [ ] Merge this PR
- [ ] Trigger the workflow with `version: 2.1.1-rc.1` (a throwaway pre-release we created during pipeline testing — safe target, no users depend on it)
- [ ] Approve the deployment
- [ ] Two possible outcomes:
  - ✅ Unlist succeeds → OIDC supports unlist. Cleanup: remove `ERROR_OR_NUGET_SECRET` from env, revoke the long-lived API key on nuget.org.
  - ❌ Auth/scope error → OIDC doesn't include unlist scope. Revert this PR and decide between (a) keeping the long-lived key with unlist scope, or (b) deleting `unlist.yml` entirely (unlist is a rare emergency op that can be done via nuget.org web UI in 10s).
- [ ] Either outcome is data we currently lack.

## Safety notes
- Targeting `2.1.1-rc.1` — a pre-release version we shipped only to test the pipeline. No production user is depending on it.
- Even if unlist accidentally succeeded on a wrong version, NuGet supports re-listing from the package management page. The operation is reversible.
- Production env approval gate still applies; nothing happens without manual approval.
