### PR TITLE
Error for empty initial error collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,24 +6,6 @@ All notable changes to this project are documented in this file.
 
 ### Added
 
-- [#159](https://github.com/amantinband/error-or/pull/159) Added `IsSuccess` property to `ErrorOr`
-
-- [#158](https://github.com/amantinband/error-or/pull/158) Added JSON Serialization support. The `IRecordable` interface provides a way to obtain a JSON representation of the current state.
-
-    ```cs
-    void Log(IErrorOr result)
-    {
-        Console.WriteLine(result.GetRecording());
-        // Or explicit call
-        Console.WriteLine(result.ToString());
-    }
-    ```
-
-- [#152](https://github.com/amantinband/error-or/pull/152) Added `ThenEnshure` and `ThenEnshureAsync` methods.
-  They are similar to `ThenDo` and `ThenDoAsync`, but they receive a function that can return errors.
-  If no errors are returned, the original value is preserved and the ensure function's success value is ignored.
-
-
 - [#94](https://github.com/amantinband/error-or/issues/94), [#95](https://github.com/amantinband/error-or/pull/95) Added missing async versions of `FailIf` methods
 
     ```cs
@@ -125,6 +107,23 @@ All notable changes to this project are documented in this file.
 
 - [#149](https://github.com/amantinband/error-or/pull/149) Added `Else`/`ElseAsync` overloads returning `ErrorOr`
 
+- [#152](https://github.com/amantinband/error-or/pull/152) Added `ThenEnshure` and `ThenEnshureAsync` methods.
+  They are similar to `ThenDo` and `ThenDoAsync`, but they receive a function that can return errors.
+  If no errors are returned, the original value is preserved and the ensure function's success value is ignored.
+
+- [#159](https://github.com/amantinband/error-or/pull/159) Added `IsSuccess` property to `ErrorOr`
+
+- [#158](https://github.com/amantinband/error-or/pull/158) Added JSON Serialization support. The `IRecordable` interface provides a way to obtain a JSON representation of the current state.
+
+    ```cs
+    void Log(IErrorOr result)
+    {
+        Console.WriteLine(result.GetRecording());
+        // Or explicit call
+        Console.WriteLine(result.ToString());
+    }
+    ```
+
 ### Fixed
 
 - [#85](https://github.com/amantinband/error-or/issues/85), [#97](https://github.com/amantinband/error-or/pull/97) `ErrorOr` turned into Value Object by reimplementing `Equals` and `GetHashCode` methods
@@ -134,6 +133,8 @@ All notable changes to this project are documented in this file.
 - [#150](https://github.com/amantinband/error-or/pull/150) `EmptyErrors.Instance` returns new `List<Error>` instance on each call
 
     This allows to avoid mutating empty list
+
+- [#178](https://github.com/amantinband/error-or/pull/178) Initializing `ErrorOr<T>` with empty or null error collection results with unexpected error.
 
 ### Optimized
 

--- a/src/ErrorOr/ErrorOr.ImplicitConverters.cs
+++ b/src/ErrorOr/ErrorOr.ImplicitConverters.cs
@@ -15,10 +15,10 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> from a list of errors.
     /// </summary>
-    public static implicit operator ErrorOr<TValue>(List<Error> errors) => new(errors);
+    public static implicit operator ErrorOr<TValue>(List<Error> errors) => errors?.Count > 0 ? new(errors) : new(KnownErrors.CachedInvalidInitialErrorsList);
 
     /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> from a list of errors.
     /// </summary>
-    public static implicit operator ErrorOr<TValue>(Error[] errors) => errors is null ? default : new ErrorOr<TValue>([.. errors]);
+    public static implicit operator ErrorOr<TValue>(Error[] errors) => errors?.Length > 0 ? new([.. errors]) : new(KnownErrors.CachedInvalidInitialErrorsList);
 }

--- a/src/Errors/KnownErrors.cs
+++ b/src/Errors/KnownErrors.cs
@@ -1,4 +1,4 @@
-﻿namespace ErrorOr;
+namespace ErrorOr;
 
 internal static class KnownErrors
 {
@@ -10,7 +10,13 @@ internal static class KnownErrors
         code: "ErrorOr.NoErrors",
         description: "Error list cannot be retrieved from a successful ErrorOr.");
 
+    public static Error EmptyInitialErrors { get; } = Error.Unexpected(
+        code: "ErrorOr.EmptyInitialErrors",
+        description: "Error list cannot be null or empty when initializing ErrorOr.");
+
     public static List<Error> CachedNoErrorsList { get; } = new (1) { NoErrors };
+
+    public static List<Error> CachedInvalidInitialErrorsList { get; } = new(1) { EmptyInitialErrors };
 
     public static List<Error> CachedEmptyErrorsList { get; } = new (0);
 }

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -585,13 +585,22 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
+    public void ImplicitCastEmptyErrorList_ShouldBeError()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = new List<Error>();
+
+        // Act & Assert
+        errorOrInt.IsError.Should().BeTrue();
+    }
+
+    [Fact]
     public void ImplicitCastEmptyErrorList_WhenAccessingValue_ShouldReturnDefault()
     {
         // Arrange
         ErrorOr<int> errorOrInt = new List<Error>();
 
         // Act & Assert
-        errorOrInt.IsError.Should().BeFalse();
         errorOrInt.Value.Should().Be(default);
     }
 
@@ -609,7 +618,7 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
-    public void ImplicitCastEmptyErrorList_WhenAccessingErrorsOrEmptyList_ShouldReturnEmptyList()
+    public void ImplicitCastEmptyErrorList_WhenAccessingErrorsOrEmptyList_ShouldReturnUnexpected()
     {
         // Arrange
         ErrorOr<int> errorOrInt = new List<Error>();
@@ -618,7 +627,7 @@ public class ErrorOrInstantiationTests
         List<Error> errors = errorOrInt.ErrorsOrEmptyList;
 
         // Assert
-        errors.Should().BeEmpty();
+        errors.Should().ContainSingle().Which.Type.Should().Be(ErrorType.Unexpected);
     }
 
     [Fact]
@@ -635,13 +644,22 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
+    public void ImplicitCastEmptyErrorArray_ShouldBeError()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = Array.Empty<Error>();
+
+        // Act & Assert
+        errorOrInt.IsError.Should().BeTrue();
+    }
+
+    [Fact]
     public void ImplicitCastEmptyErrorArray_WhenAccessingValue_ShouldReturnDefault()
     {
         // Arrange
         ErrorOr<int> errorOrInt = Array.Empty<Error>();
 
         // Act & Assert
-        errorOrInt.IsError.Should().BeFalse();
         errorOrInt.Value.Should().Be(default);
     }
 
@@ -659,7 +677,7 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
-    public void ImplicitCastEmptyErrorArray_WhenAccessingErrorsOrEmptyList_ShouldReturnEmptyList()
+    public void ImplicitCastEmptyErrorArray_WhenAccessingErrorsOrEmptyList_ShouldReturnUnexpected()
     {
         // Arrange
         ErrorOr<int> errorOrInt = Array.Empty<Error>();
@@ -668,7 +686,7 @@ public class ErrorOrInstantiationTests
         List<Error> errors = errorOrInt.ErrorsOrEmptyList;
 
         // Assert
-        errors.Should().BeEmpty();
+        errors.Should().ContainSingle().Which.Type.Should().Be(ErrorType.Unexpected);
     }
 
     [Fact]
@@ -735,13 +753,22 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
+    public void ImplicitCastNullErrorList_ShouldBeError()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = default(List<Error>)!;
+
+        // Act & Assert
+        errorOrInt.IsError.Should().BeTrue();
+    }
+
+    [Fact]
     public void ImplicitCastNullErrorList_WhenAccessingValue_ShouldReturnDefault()
     {
         // Arrange
         ErrorOr<int> errorOrInt = default(List<Error>)!;
 
         // Act & Assert
-        errorOrInt.IsError.Should().BeFalse();
         errorOrInt.Value.Should().Be(default);
     }
 
@@ -759,7 +786,7 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
-    public void ImplicitCastNullErrorList_WhenAccessingErrorsOrEmptyList_ShouldReturnEmptyList()
+    public void ImplicitCastNullErrorList_WhenAccessingErrorsOrEmptyList_ShouldReturnUnexpected()
     {
         // Arrange
         ErrorOr<int> errorOrInt = default(List<Error>)!;
@@ -768,7 +795,7 @@ public class ErrorOrInstantiationTests
         List<Error> errors = errorOrInt.ErrorsOrEmptyList;
 
         // Assert
-        errors.Should().BeEmpty();
+        errors.Should().ContainSingle().Which.Type.Should().Be(ErrorType.Unexpected);
     }
 
     [Fact]
@@ -785,13 +812,22 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
+    public void ImplicitCastNullErrorArray_ShouldBeError()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = default(Error[])!;
+
+        // Act & Assert
+        errorOrInt.IsError.Should().BeTrue();
+    }
+
+    [Fact]
     public void ImplicitCastNullErrorArray_WhenAccessingValue_ShouldReturnDefault()
     {
         // Arrange
         ErrorOr<int> errorOrInt = default(Error[])!;
 
         // Act & Assert
-        errorOrInt.IsError.Should().BeFalse();
         errorOrInt.Value.Should().Be(default);
     }
 
@@ -809,7 +845,7 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
-    public void ImplicitCastNullErrorArray_WhenAccessingErrorsOrEmptyList_ShouldReturnEmptyList()
+    public void ImplicitCastNullErrorArray_WhenAccessingErrorsOrEmptyList_ShouldReturnUnexpected()
     {
         // Arrange
         ErrorOr<int> errorOrInt = default(Error[])!;
@@ -818,7 +854,7 @@ public class ErrorOrInstantiationTests
         List<Error> errors = errorOrInt.ErrorsOrEmptyList;
 
         // Assert
-        errors.Should().BeEmpty();
+        errors.Should().ContainSingle().Which.Type.Should().Be(ErrorType.Unexpected);
     }
 
     [Fact]

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -542,6 +542,16 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
+    public void ErrorOr_FromEmptyErrorCollectionExpression_ShouldBeError()
+    {
+        // Act
+        ErrorOr<Person> errorOrPerson = [];
+
+        // Assert
+        errorOrPerson.IsError.Should().BeTrue();
+    }
+
+    [Fact]
     public void GenericErrorOrInterface_FromErrorCollectionExpression_WhenAccessingErrors_ShouldReturnErrorList()
     {
         // Arrange


### PR DESCRIPTION
Initializing `ErrorOr<T>` with empty or null error collection an is obvious misuse. Now it results in creating `ErrorOr<T>` instance with single unexpected error.