### PR TITLE
Tests should run for all supported TFM's

### DIFF
--- a/tests/IsExternalInit.cs
+++ b/tests/IsExternalInit.cs
@@ -1,0 +1,10 @@
+#if !NET5_0_OR_GREATER
+namespace System.Runtime.CompilerServices
+{
+    // Backfill for older target frameworks/SDKs that don't expose IsExternalInit
+    // Allows usage of init-only setters and record types when building against e.g. .NET Framework / netstandard2.0.
+    internal static class IsExternalInit
+    {
+    }
+}
+#endif

--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net462;net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Added  running tests for all supported Target Framework Monikers:
- net10.0 for .NET 10
- net8.0 for .NET 8
- net462 to test .NET Standard 2.0 version

Multi-targeted NuGet packages contains separate DLL for each target framework moniker so every dll should be tested.