### PR TITLE
Try to fix NuGet Test Problems

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,5 +19,13 @@ jobs:
                   dotnet-version: 10.0.x
             - name: Restore dependencies
               run: dotnet restore
-            - run: dotnet build -c Release --no-restore
-            - run: dotnet test -c Release --no-restore --verbosity normal
+            - name: Build
+              run: dotnet build -c Release --no-restore
+            - name: Test Debug
+              run: dotnet test -c Debug --no-restore --verbosity normal --collect:"XPlat Code Coverage"
+            - name: Test Release
+              run: dotnet test -c Release --no-restore --verbosity normal --collect:"XPlat Code Coverage"
+            - name: Upload coverage to Codecov
+              uses: codecov/codecov-action@v6
+              with:
+                  token: ${{ secrets.CODE_COV_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
             - name: Setup .NET
               uses: actions/setup-dotnet@v5
               with:
-                  dotnet-version: 8.0.x
+                  dotnet-version: 10.0.x
             - name: Restore dependencies
               run: dotnet restore
             - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,13 +19,5 @@ jobs:
                   dotnet-version: 10.0.x
             - name: Restore dependencies
               run: dotnet restore
-            - name: Build
-              run: dotnet build -c Release --no-restore
-            - name: Test Debug
-              run: dotnet test -c Debug --no-restore --verbosity normal --collect:"XPlat Code Coverage"
-            - name: Test Release
-              run: dotnet test -c Release --no-restore --verbosity normal --collect:"XPlat Code Coverage"
-            - name: Upload coverage to Codecov
-              uses: codecov/codecov-action@v6
-              with:
-                  token: ${{ secrets.CODE_COV_TOKEN }}
+            - run: dotnet build -c Release --no-restore
+            - run: dotnet test -c Release --no-restore --verbosity normal

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
     build:
-        runs-on: windows-latest
+        runs-on: ubuntu-latest
 
         steps:
             - uses: actions/checkout@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
     build:
-        runs-on: ubuntu-latest
+        runs-on: windows-latest
 
         steps:
             - uses: actions/checkout@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
       - run: dotnet restore
       - run: dotnet build -c Release --no-restore
       - run: dotnet test -c Release --no-restore --verbosity normal
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
       - name: Resolve version
         id: version
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   test:
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-dotnet@v5
@@ -30,7 +30,7 @@ jobs:
   publish:
     name: Pack and publish
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     environment: production
     permissions:
       id-token: write

--- a/.github/workflows/unlist.yml
+++ b/.github/workflows/unlist.yml
@@ -18,7 +18,7 @@ jobs:
         steps:
             - uses: actions/setup-dotnet@v5
               with:
-                  dotnet-version: 8.0.x
+                  dotnet-version: 10.0.x
             - name: NuGet login (OIDC -> short-lived API key)
               uses: NuGet/login@v1
               id: nuget-login

--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
We had problems that the tag release is broken. The only ideas we had where to upgrade the .net Version and remove the currently added .net462 for the unit tests and try it again.

- Update workflows to use .NET 10.0.x
- removed .net462 from Unit Test Project