### PR TITLE
Force bash shell on publish workflow Resolve version step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,7 @@ jobs:
           dotnet-version: 10.0.x
       - name: Resolve version
         id: version
+        shell: bash
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             VERSION="${{ inputs.version }}"


### PR DESCRIPTION
## Summary
One-line fix: pin `shell: bash` on the `Resolve version` step in `publish.yml`.

## Why
PR #182 changed the publish job runner from `ubuntu-latest` to `windows-latest`. On Windows runners, the default shell is PowerShell, which can't parse the bash-only syntax in this step (`if [ ... ]; then`, `${VAR#prefix}` parameter expansion). Every release attempt since #182 merged has died here with `Missing '(' after 'if' in if statement` before reaching the NuGet login step.

This is why `v2.1.1-rc.4` shows three failed/cancelled runs and isn't on NuGet despite the tag existing.

## Fix
Pinning `shell: bash` keeps the script working regardless of runner OS — Git Bash is bundled with Windows runners.

## Followup
After merging, a maintainer should re-tag as `v2.1.1-rc.5` (rc.4 has been consumed by the failed runs). I'll review and approve the new run.
