### PR TITLE
publish.yml: default the whole job to bash, not just one step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,9 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-dotnet@v5
@@ -42,7 +45,6 @@ jobs:
           dotnet-version: 10.0.x
       - name: Resolve version
         id: version
-        shell: bash
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             VERSION="${{ inputs.version }}"


### PR DESCRIPTION
## Summary
Follow-up to #192. Sets `defaults.run.shell: bash` at the publish job level instead of pinning per-step.

## Why
#192 pinned `shell: bash` only on the `Resolve version` step. The very next attempted release (run [25627626486](https://github.com/error-or/error-or/actions/runs/25627626486)) failed at the `Publish to NuGet` step with:

```
error: File does not exist (artifacts/*.nupkg).
shell: C:\Program Files\PowerShell\7\pwsh.EXE
```

Cause: `dotnet nuget push "artifacts/*.nupkg"` relies on shell glob expansion, which PowerShell does not perform on quoted arguments on Windows runners. The literal pattern reaches dotnet, which can't find a file named `*.nupkg`.

The job-level default catches all current `run:` steps (resolve version, pack, push) and any future ones, so we stop patching one bash-ism at a time.

## Followup
After merging, re-tag `v2.1.1-rc.4` once more (or move to `rc.5` if cleaner). I'll re-approve.

## Note for the maintainers
The publish workflow was originally designed for `ubuntu-latest`. PR #182 changed it to `windows-latest` for consistency with `build.yml`, which surfaced these latent bash dependencies. Two reasonable long-term options: keep on Windows with `shell: bash` defaulted (this PR), or move publish back to `ubuntu-latest` (NuGet publish doesn't need Windows). Either works.
