### PR TITLE
CHANGELOG fixes before 2.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,8 +202,6 @@ All notable changes to this project are documented in this file.
 
 - [#98](https://github.com/amantinband/error-or/issues/98), [#99](https://github.com/amantinband/error-or/pull/99) Memory consumption optimized by moving static empty errors lists from generic struct into non-generic class
 
-- [#128](https://github.com/error-or/error-or/pull/128) Removed unneccessary null check from `ErrorOr(List<Error>)` constructor
-
 ### Refactored
 
 - [#154](https://github.com/amantinband/error-or/pull/154) Modernized NuGet publish workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,14 +155,36 @@ All notable changes to this project are documented in this file.
 
 - [#159](https://github.com/amantinband/error-or/pull/159) Added `IsSuccess` property to `ErrorOr`
 
-- [#158](https://github.com/amantinband/error-or/pull/158) Added JSON Serialization support. The `IRecordable` interface provides a way to obtain a JSON representation of the current state.
+- [#158](https://github.com/amantinband/error-or/pull/158) Added support for serialization via `IErrorOr` interface without direct access to `Value` property. The `IRecordable` base interface provides a way to obtain a serialized representation of the current state.
 
     ```cs
     void Log(IErrorOr result)
     {
-        Console.WriteLine(result.GetRecording());
-        // Or explicit call
-        Console.WriteLine(result.ToString());
+        Console.WriteLine(result.GetRecording(serializer));
+    }
+    ```
+
+    `IRecordingSerializer<TOutput>` interface can be implemented to provide concrete serialization strategy, for exaple JSON serialization:
+
+    ```cs
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
+    using ErrorOr;
+
+    public class SystemTextJsonRecordingSerializer : IRecordingSerializer<string>
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            WriteIndented = true,
+            Converters = { new JsonStringEnumConverter() },
+            DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+        };
+
+        public string SerializeValue<TValue>(TValue value)
+            => JsonSerializer.Serialize(value, JsonOptions);
+
+        public string SerializeErrors(List<Error> errors)
+            => JsonSerializer.Serialize(errors, JsonOptions);
     }
     ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,7 +148,7 @@ All notable changes to this project are documented in this file.
 
 - [#149](https://github.com/amantinband/error-or/pull/149) Added `Else`/`ElseAsync` overloads returning `ErrorOr`
 
-- [#152](https://github.com/amantinband/error-or/pull/152) Added `ThenEnshure` and `ThenEnshureAsync` methods.
+- [#152](https://github.com/amantinband/error-or/pull/152) Added `ThenEnsure` and `ThenEnsureAsync` methods.
 
     They are similar to `ThenDo` and `ThenDoAsync`, but they receive a function that can return errors.
     If no errors are returned, the original value is preserved and the ensure function's success value is ignored.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,10 +196,6 @@ All notable changes to this project are documented in this file.
 
     New dependency was introduced to [Microsoft.Bcl.HashCode](https://www.nuget.org/packages/Microsoft.Bcl.HashCode) and development dependency was introduced to [Nullable](https://www.nuget.org/packages/Nullable)
 
-- [#150](https://github.com/amantinband/error-or/pull/150) `EmptyErrors.Instance` returns new `List<Error>` instance on each call
-
-    This allows to avoid mutating empty list
-
 - [#178](https://github.com/amantinband/error-or/pull/178) Initializing `ErrorOr<T>` with empty or null error collection results with unexpected error.
 
 ### Optimized

--- a/src/ErrorOr/EmptyErrors.cs
+++ b/src/ErrorOr/EmptyErrors.cs
@@ -1,6 +1,0 @@
-namespace ErrorOr;
-
-internal static class EmptyErrors
-{
-    public static List<Error> Instance => new();
-}


### PR DESCRIPTION
Some minor CHANGELOG fixes introduced to make it correct in 2.1.1:
- Fixed typo in `Ensure` methods
- Updated `IRecordable` description after serialzer were introduced
- Deleted unused `EmptyErrors` class and unneccessary changelog entry
- Deleted unneccessary null check description from changelog as it is no longer relevant

These changes are required to #131 