### PR TITLE
publish: skip the glob, push an explicit nupkg filename

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,5 @@ jobs:
         id: nuget-login
         with:
           user: ${{ secrets.NUGET_USER }}
-      - name: Show artifacts
-        run: ls -la artifacts
       - name: Publish to NuGet
-        run: dotnet nuget push "./artifacts/*.nupkg" --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push "artifacts/ErrorOr.${{ steps.version.outputs.version }}.nupkg" --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
## Summary
Follow-up to #192, #193, #195. Drops the glob pattern in `dotnet nuget push` and uses an explicit filename built from the resolved version. Also removes the temporary `Show artifacts` debug step from #195.

## Why
`dotnet nuget push` has a long-standing bug on Windows runners where it can't resolve forward-slash glob patterns — confirmed in [dotnet/sdk#23459](https://github.com/dotnet/sdk/issues/23459) and [dotnet/sdk#39569](https://github.com/dotnet/sdk/issues/39569). The workaround documented there is to use Windows-style backslashes (`artifacts\*.nupkg`), but that ties the workflow to a specific OS.

Since we already resolve the version into `steps.version.outputs.version`, we can construct the exact `.nupkg` filename and skip glob expansion entirely. No bug-class to fight, works on any OS or shell, and the workflow becomes explicit about which file ships.

## Test plan
- [ ] Merge
- [ ] Maintainer re-tags `v2.1.1-rc.4` once more (or moves to `v2.1.1-rc.5` if cleaner)
- [ ] Confirm the push step succeeds end to end and `ErrorOr.2.1.1-rc.4.nupkg` lands on nuget.org as a pre-release

## Note
This is the fourth fix attempt at this same release. Apologies for the noise — root cause was a known dotnet SDK bug, not anything specific to our setup. Going forward, explicit filenames means we'll never hit it again.
