### PR TITLE
Add CHANGELOG as release notes in NuGet package

### DIFF
--- a/src/ErrorOr.csproj
+++ b/src/ErrorOr.csproj
@@ -18,10 +18,12 @@
     <RepositoryUrl>https://github.com/error-or/error-or</RepositoryUrl>
     <PackageOutputPath>../artifacts/</PackageOutputPath>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReleaseNotes>CHANGELOG.md</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
     <None Include="../assets/icon-square.png" Pack="true" Visible="false" PackagePath="" />
     <None Include="../README.md" Pack="true" PackagePath="" />
+    <None Include="../CHANGELOG.md" Pack="true" PackagePath="" />
     <None Include="Stylecop.json" />
     <AdditionalFiles Include="Stylecop.json" />
   </ItemGroup>


### PR DESCRIPTION
I did not noticed tha CHANGELOG.md file is not being addded to NuGet package and therefore no release notes section is being presented in [nuget.org ErrorOr gallery site](https://www.nuget.org/packages/ErrorOr).  I add this for next releases.