### PR TITLE
[Breaking] Make collections read-only

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -70,3 +70,6 @@ dotnet_diagnostic.SA1642.severity = none
 
 # SA1516: Elements should be separated by blank line
 dotnet_diagnostic.SA1516.severity = none
+
+[*.csproj]
+indent_size = 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented in this file.
 
-## [2.1.1] - to be released
+## [2.1.1] - 2026-05-15
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ Consequently all `Match`, `Switch` and `Else` methods and extension methods that
 
 ```diff
 -    public ErrorOr<TValue> Else(Func<List<Error>, List<Error>> onError)
-+    public ErrorOr<TValue> Else(Func<ReadOnlyCollection<Error>, List<Error>> onError)
++    public ErrorOr<TValue> Else(Func<ReadOnlyCollection<Error>, ReadOnlyCollection<Error>> onError)
 ```
 
 ```diff
@@ -127,7 +127,7 @@ Consequently all `Match`, `Switch` and `Else` methods and extension methods that
 
 ```diff
 -    public async Task<ErrorOr<TValue>> ElseAsync(Func<List<Error>, Task<List<Error>>> onError)
-+    public async Task<ErrorOr<TValue>> ElseAsync(Func<ReadOnlyCollection<Error>, Task<List<Error>>> onError)
++    public async Task<ErrorOr<TValue>> ElseAsync(Func<ReadOnlyCollection<Error>, Task<ReadOnlyCollection<Error>>> onError)
 ```
 
 ```diff
@@ -145,38 +145,45 @@ Consequently all `Match`, `Switch` and `Else` methods and extension methods that
 ```
 
 ```diff
-     public static async Task<ErrorOr<TValue>> ElseAsync<TValue>(
-         this Task<ErrorOr<TValue>> errorOr,
--        Func<List<Error>, Task<TValue>> onError)
-+        Func<ReadOnlyCollection<Error>, Task<TValue>> onError)
+    public static async Task<ErrorOr<TValue>> ElseAsync<TValue>(
+        this Task<ErrorOr<TValue>> errorOr,
+-       Func<List<Error>, Task<TValue>> onError)
++       Func<ReadOnlyCollection<Error>, Task<TValue>> onError)
 ```
 
 ```diff
-     public static async Task<ErrorOr<TValue>> ElseAsync<TValue>(
-         this Task<ErrorOr<TValue>> errorOr,
--        Func<List<Error>, Task<ErrorOr<TValue>>> onError)
-+        Func<ReadOnlyCollection<Error>, Task<ErrorOr<TValue>>> onError)
+    public static async Task<ErrorOr<TValue>> ElseAsync<TValue>(
+        this Task<ErrorOr<TValue>> errorOr,
+-       Func<List<Error>, Task<ErrorOr<TValue>>> onError)
++       Func<ReadOnlyCollection<Error>, Task<ErrorOr<TValue>>> onError)
 ```
 
 ```diff
-     public static async Task<ErrorOr<TValue>> Else<TValue>(
-         this Task<ErrorOr<TValue>> errorOr,
--        Func<List<Error>, Error> onError)
-+        Func<ReadOnlyCollection<Error>, Error> onError)
+    public static async Task<ErrorOr<TValue>> Else<TValue>(
+        this Task<ErrorOr<TValue>> errorOr,
+-       Func<List<Error>, Error> onError)
++       Func<ReadOnlyCollection<Error>, Error> onError)
 ```
 
 ```diff
-     public static async Task<ErrorOr<TValue>> Else<TValue>(
-         this Task<ErrorOr<TValue>> errorOr,
--        Func<List<Error>, List<Error>> onError)
-+        Func<ReadOnlyCollection<Error>, List<Error>> onError)
+    public static async Task<ErrorOr<TValue>> Else<TValue>(
+        this Task<ErrorOr<TValue>> errorOr,
+-       Func<List<Error>, List<Error>> onError)
++       Func<ReadOnlyCollection<Error>, ReadOnlyCollection<Error>> onError)
 ```
 
 ```diff
-     public static async Task<ErrorOr<TValue>> ElseAsync<TValue>(
-         this Task<ErrorOr<TValue>> errorOr,
--        Func<List<Error>, Task<Error>> onError)
-+        Func<ReadOnlyCollection<Error>, Task<Error>> onError)
+    public static async Task<ErrorOr<TValue>> ElseAsync<TValue>(
+        this Task<ErrorOr<TValue>> errorOr,
+-       Func<List<Error>, Task<Error>> onError)
++       Func<ReadOnlyCollection<Error>, Task<Error>> onError)
+```
+
+```diff
+    public static async Task<ErrorOr<TValue>> ElseAsync<TValue>(
+        this Task<ErrorOr<TValue>> errorOr,
+-       Func<List<Error>, Task<List<Error>>> onError)
++       Func<ReadOnlyCollection<Error>, Task<ReadOnlyCollection<Error>>> onError)
 ```
 
 ```diff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,286 @@
 
 All notable changes to this project are documented in this file.
 
+## [3.0.0] - to be released
+
+### Breaking Changes
+
+- `IErrorOr.Errors`, `ErrorOr.Errors` and `ErrorOr.ErrorsOrEmptyList` changes type from `List<Error>` to `ReadOnlyCollection<Error>`
+
+Implicit converter from `ReadOnlyCollection<Error>` was added. Implicit converter from `List<Error>` was rewritten to create new read-only collection. Implicit converter from `Error[]` was effectively replaced with implicit converter from `ReadOnlySpan<Error>`. Collection expression from list of errors was rewritten to use this implicit converter.
+
+`ErrorOrFactory.From` methods accepting `List<Error>` and `IEnumerable<Error>` along with their async variants were removed and effectively replaced with methods accepting `ReadOnlySpan<Error>`.
+
+Consequently all `Match`, `Switch` and `Else` methods and extension methods that accepted delegates with `List<Error>` as first argument now accepts delegates with `ReadOnlyCollection<Error>` as first argument. Those which expect `List<Error>` as a delegate result still expect it and convert into read-only collection upon implicit conversion.
+
+`Match`, `MatchAsync` methods and extension methods:
+
+```diff
+     public TNextValue Match<TNextValue>(
+         Func<TValue, TNextValue> onValue,
+-        Func<List<Error>, TNextValue> onError)
++        Func<ReadOnlyCollection<Error>, TNextValue> onError)
+```
+
+```diff
+     public async Task<TNextValue> MatchAsync<TNextValue>(
+         Func<TValue, Task<TNextValue>> onValue,
+-        Func<List<Error>, Task<TNextValue>> onError)
++        Func<ReadOnlyCollection<Error>, Task<TNextValue>> onError)
+```
+
+```diff
+     public static async Task<TNextValue> Match<TValue, TNextValue>(
+         this Task<ErrorOr<TValue>> errorOr,
+         Func<TValue, TNextValue> onValue,
+-        Func<List<Error>, TNextValue> onError)
++        Func<ReadOnlyCollection<Error>, TNextValue> onError)
+```
+
+```diff
+     public static async Task<TNextValue> MatchAsync<TValue, TNextValue>(
+         this Task<ErrorOr<TValue>> errorOr,
+         Func<TValue, Task<TNextValue>> onValue,
+-        Func<List<Error>, Task<TNextValue>> onError)
++        Func<ReadOnlyCollection<Error>, Task<TNextValue>> onError)
+```
+
+`Switch`, `SwitchAsync` methods and extension methods:
+
+```diff
+     public void Switch(
+         Action<TValue> onValue,
+-        Action<List<Error>> onError)
++        Action<ReadOnlyCollection<Error>> onError)
+```
+
+```diff
+     public async Task SwitchAsync(
+         Func<TValue, Task> onValue,
+-        Func<List<Error>, Task> onError)
++        Func<ReadOnlyCollection<Error>, Task> onError)
+```
+
+```diff
+     public static async Task Switch<TValue>(
+         this Task<ErrorOr<TValue>> errorOr,
+         Action<TValue> onValue,
+-        Action<List<Error>> onError)
++        Action<ReadOnlyCollection<Error>> onError)
+```
+
+```diff
+     public static async Task SwitchAsync<TValue>(
+         this Task<ErrorOr<TValue>> errorOr,
+         Func<TValue, Task> onValue,
+-        Func<List<Error>, Task> onError)
++        Func<ReadOnlyCollection<Error>, Task> onError)
+```
+
+`Else`, `ElseAsync` methods and extension methods:
+
+```diff
+-    public ErrorOr<TValue> Else(Func<List<Error>, Error> onError)
++    public ErrorOr<TValue> Else(Func<ReadOnlyCollection<Error>, Error> onError)
+```
+
+```diff
+-    public ErrorOr<TValue> Else(Func<List<Error>, List<Error>> onError)
++    public ErrorOr<TValue> Else(Func<ReadOnlyCollection<Error>, List<Error>> onError)
+```
+
+```diff
+-    public ErrorOr<TValue> Else(Func<List<Error>, TValue> onError)
++    public ErrorOr<TValue> Else(Func<ReadOnlyCollection<Error>, TValue> onError)
+```
+
+```diff
+-    public ErrorOr<TValue> Else(Func<List<Error>, ErrorOr<TValue>> onError)
++    public ErrorOr<TValue> Else(Func<ReadOnlyCollection<Error>, ErrorOr<TValue>> onError)
+```
+
+```diff
+-    public ErrorOr<TValue> ElseDo(Action<List<Error>> action)
++    public ErrorOr<TValue> ElseDo(Action<ReadOnlyCollection<Error>> action)
+```
+
+```diff
+-    public async Task<ErrorOr<TValue>> ElseDoAsync(Func<List<Error>, Task> action)
++    public async Task<ErrorOr<TValue>> ElseDoAsync(Func<ReadOnlyCollection<Error>, Task> action)
+```
+
+```diff
+-    public async Task<ErrorOr<TValue>> ElseAsync(Func<List<Error>, Task<TValue>> onError)
++    public async Task<ErrorOr<TValue>> ElseAsync(Func<ReadOnlyCollection<Error>, Task<TValue>> onError)
+```
+
+```diff
+-    public async Task<ErrorOr<TValue>> ElseAsync(Func<List<Error>, Task<ErrorOr<TValue>>> onError)
++    public async Task<ErrorOr<TValue>> ElseAsync(Func<ReadOnlyCollection<Error>, Task<ErrorOr<TValue>>> onError)
+```
+
+```diff
+-    public async Task<ErrorOr<TValue>> ElseAsync(Func<List<Error>, Task<Error>> onError)
++    public async Task<ErrorOr<TValue>> ElseAsync(Func<ReadOnlyCollection<Error>, Task<Error>> onError)
+```
+
+```diff
+-    public async Task<ErrorOr<TValue>> ElseAsync(Func<List<Error>, Task<List<Error>>> onError)
++    public async Task<ErrorOr<TValue>> ElseAsync(Func<ReadOnlyCollection<Error>, Task<List<Error>>> onError)
+```
+
+```diff
+     public static async Task<ErrorOr<TValue>> Else<TValue>(
+        this Task<ErrorOr<TValue>> errorOr,
+-       Func<List<Error>, TValue> onError)
++       Func<ReadOnlyCollection<Error>, TValue> onError)
+```
+
+```diff
+    public static async Task<ErrorOr<TValue>> Else<TValue>(
+        this Task<ErrorOr<TValue>> errorOr,
+-       Func<List<Error>, ErrorOr<TValue>> onError)
++       Func<ReadOnlyCollection<Error>, ErrorOr<TValue>> onError)
+```
+
+```diff
+     public static async Task<ErrorOr<TValue>> ElseAsync<TValue>(
+         this Task<ErrorOr<TValue>> errorOr,
+-        Func<List<Error>, Task<TValue>> onError)
++        Func<ReadOnlyCollection<Error>, Task<TValue>> onError)
+```
+
+```diff
+     public static async Task<ErrorOr<TValue>> ElseAsync<TValue>(
+         this Task<ErrorOr<TValue>> errorOr,
+-        Func<List<Error>, Task<ErrorOr<TValue>>> onError)
++        Func<ReadOnlyCollection<Error>, Task<ErrorOr<TValue>>> onError)
+```
+
+```diff
+     public static async Task<ErrorOr<TValue>> Else<TValue>(
+         this Task<ErrorOr<TValue>> errorOr,
+-        Func<List<Error>, Error> onError)
++        Func<ReadOnlyCollection<Error>, Error> onError)
+```
+
+```diff
+     public static async Task<ErrorOr<TValue>> Else<TValue>(
+         this Task<ErrorOr<TValue>> errorOr,
+-        Func<List<Error>, List<Error>> onError)
++        Func<ReadOnlyCollection<Error>, List<Error>> onError)
+```
+
+```diff
+     public static async Task<ErrorOr<TValue>> ElseAsync<TValue>(
+         this Task<ErrorOr<TValue>> errorOr,
+-        Func<List<Error>, Task<Error>> onError)
++        Func<ReadOnlyCollection<Error>, Task<Error>> onError)
+```
+
+```diff
+    public static async Task<ErrorOr<TValue>> ElseDo<TValue>(
+        this Task<ErrorOr<TValue>> errorOr,
+-       Action<List<Error>> action)
++       Action<ReadOnlyCollection<Error>> action)
+```
+
+```diff
+    public static async Task<ErrorOr<TValue>> ElseDoAsync<TValue>(
+        this Task<ErrorOr<TValue>> errorOr,
+-       Func<List<Error>, Task> action)
++       Func<ReadOnlyCollection<Error>, Task> action)
+```
+
+- `IRecordingSerializer<TOutput>.SerializeErrors` now accepts `ReadOnlyCollection<Error>` instead of `List<Error>`.
+
+- Obsolete `ErrorOr<TValue>.From` method that accepted `List<Error>` is now removed.
+
+- `Error.Metadata` property type chages from `Dictionary<string, object>` to `ReadOnlyDictionary<string, object>`
+
+- Static factory methods of `Error` accepts `IDictionary<string, object>` instead of `Dictionary<string, object>`
+
+```diff
+     public static Error Failure(
+         string code = "General.Failure",
+         string description = "A failure has occurred.",
+-        Dictionary<string, object>? metadata = null)
++        IDictionary<string, object>? metadata = null)
+```
+
+```diff
+     public static Error Unexpected(
+         string code = "General.Unexpected",
+         string description = "An unexpected error has occurred.",
+-        Dictionary<string, object>? metadata = null)
++        IDictionary<string, object>? metadata = null)
+```
+
+```diff
+     public static Error Validation(
+         string code = "General.Validation",
+         string description = "A validation error has occurred.",
+-        Dictionary<string, object>? metadata = null)
++        IDictionary<string, object>? metadata = null)
+```
+
+```diff
+     public static Error Conflict(
+         string code = "General.Conflict",
+         string description = "A conflict error has occurred.",
+-        Dictionary<string, object>? metadata = null)
++        IDictionary<string, object>? metadata = null)
+```
+
+```diff
+     public static Error NotFound(
+         string code = "General.NotFound",
+         string description = "A 'Not Found' error has occurred.",
+-        Dictionary<string, object>? metadata = null)
++        IDictionary<string, object>? metadata = null)
+```
+
+```diff
+     public static Error Unauthorized(
+         string code = "General.Unauthorized",
+         string description = "An 'Unauthorized' error has occurred.",
+-        Dictionary<string, object>? metadata = null)
++        IDictionary<string, object>? metadata = null)
+```
+
+```diff
+     public static Error Forbidden(
+         string code = "General.Forbidden",
+         string description = "A 'Forbidden' error has occurred.",
+-        Dictionary<string, object>? metadata = null)
++        IDictionary<string, object>? metadata = null)
+```
+
+```diff
+    public static Error Custom(
+         int type,
+         string code,
+         string description,
+-        Dictionary<string, object>? metadata = null)
++        IDictionary<string, object>? metadata = null)
+```
+
+### Added
+
+- New `ToErrorOr` extension method was added for `ReadOnlyCollection<Error>` along with its async version.
+
+```csharp
+ReadOnlyCollection<Error> errors = new([Error.Unauthorized(), Error.Validation()]);
+ErrorOr<int> result = errors.ToErrorOr<int>();
+```
+
+- New `ErrorOr` implicit converter was added for `ReadOnlyCollection<Error>`
+
+```csharp
+ReadOnlyCollection<Error> errors = new([Error.Unauthorized(), Error.Validation()]);
+ErrorOr<int> result = errors;
+```
+
 ## [2.1.1] - 2026-05-15
 
 ### Added

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,6 @@
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
         <PackageVersion Include="xunit" Version="2.9.3" />
         <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-        <PackageVersion Include="coverlet.collector" Version="10.0.0" />
+        <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ ErrorOr<string> foo = await "5".ToErrorOr()
 
 ## Using implicit conversion
 
-There are implicit converters from `TResult`, `Error`, `List<Error>` to `ErrorOr<TResult>`
+There are implicit converters from `TResult`, `Error`, `ReadOnlyCollection<Error>`, `List<Error>`, Error[] to `ErrorOr<TResult>`
 
 ```cs
 ErrorOr<int> result = 5;
@@ -421,11 +421,11 @@ ErrorOr<int> result = User.Create();
 
 if (result.IsError)
 {
-    result.ErrorsOrEmptyList // List<Error> { /* one or more errors */  }
+    result.ErrorsOrEmptyList // ReadOnlyCollection<Error> { /* one or more errors */  }
     return;
 }
 
-result.ErrorsOrEmptyList // List<Error> { }
+result.ErrorsOrEmptyList // ReadOnlyCollection<Error> { }
 ```
 
 # Methods
@@ -713,7 +713,7 @@ Because `IErrorOr` inherits from `IRecordable`, `GetRecording(IRecordingSerializ
 public interface IRecordingSerializer<TOutput>
 {
     TOutput SerializeValue<TValue>(TValue value);
-    TOutput SerializeErrors(List<Error> errors);
+    TOutput SerializeErrors(ReadOnlyCollection<Error> errors);
 }
 ```
 
@@ -738,7 +738,7 @@ public class SystemTextJsonRecordingSerializer : IRecordingSerializer<string>
     public string SerializeValue<TValue>(TValue value)
         => JsonSerializer.Serialize(value, JsonOptions);
 
-    public string SerializeErrors(List<Error> errors)
+    public string SerializeErrors(ReadOnlyCollection<Error> errors)
         => JsonSerializer.Serialize(errors, JsonOptions);
 }
 ```
@@ -783,7 +783,7 @@ public class PlainTextRecordingSerializer : IRecordingSerializer<string>
     public string SerializeValue<TValue>(TValue value)
         => value?.ToString() ?? string.Empty;
 
-    public string SerializeErrors(List<Error> errors)
+    public string SerializeErrors(ReadOnlyCollection<Error> errors)
         => string.Join(", ", errors.Select(e => $"{e.Code}: {e.Description}"));
 }
 
@@ -793,7 +793,7 @@ public class ProtobufRecordingSerializer : IRecordingSerializer<byte[]>
     public byte[] SerializeValue<TValue>(TValue value)
         => ProtoBuf.Serializer.SerializeWithLengthPrefix<TValue>(value);
 
-    public byte[] SerializeErrors(List<Error> errors)
+    public byte[] SerializeErrors(ReadOnlyCollection<Error> errors)
         => ProtoBuf.Serializer.SerializeWithLengthPrefix(errors);
 }
 ```

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ ErrorOr<string> foo = await "5".ToErrorOr()
 
 ## Using implicit conversion
 
-There are implicit converters from `TResult`, `Error`, `ReadOnlyCollection<Error>`, `List<Error>`, Error[] to `ErrorOr<TResult>`
+There are implicit converters from `TResult`, `Error`, `ReadOnlyCollection<Error>`, `List<Error>`, `Error[]` to `ErrorOr<TResult>`
 
 ```cs
 ErrorOr<int> result = 5;

--- a/src/ErrorOr.csproj
+++ b/src/ErrorOr.csproj
@@ -18,10 +18,12 @@
     <RepositoryUrl>https://github.com/error-or/error-or</RepositoryUrl>
     <PackageOutputPath>../artifacts/</PackageOutputPath>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReleaseNotes>CHANGELOG.md</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
     <None Include="../assets/icon-square.png" Pack="true" Visible="false" PackagePath="" />
     <None Include="../README.md" Pack="true" PackagePath="" />
+    <None Include="../CHANGELOG.md" Pack="true" PackagePath="" />
     <None Include="Stylecop.json" />
     <AdditionalFiles Include="Stylecop.json" />
   </ItemGroup>

--- a/src/ErrorOr.csproj
+++ b/src/ErrorOr.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -20,6 +20,9 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>CHANGELOG.md</PackageReleaseNotes>
   </PropertyGroup>
+  <ItemGroup>
+    <Using Include="System.Collections.ObjectModel" />
+  </ItemGroup>
   <ItemGroup>
     <None Include="../assets/icon-square.png" Pack="true" Visible="false" PackagePath="" />
     <None Include="../README.md" Pack="true" PackagePath="" />

--- a/src/ErrorOr/CollectionExpression.cs
+++ b/src/ErrorOr/CollectionExpression.cs
@@ -14,7 +14,7 @@ public static class CollectionExpression
     /// <remarks>Enables support for collection expressions.</remarks>
     public static ErrorOr<TValue> CreateErrorOr<TValue>(ReadOnlySpan<Error> errors)
     {
-        return errors.ToArray();
+        return errors;
     }
 
     /// <summary>

--- a/src/ErrorOr/CollectionExpression.cs
+++ b/src/ErrorOr/CollectionExpression.cs
@@ -12,10 +12,7 @@ public static class CollectionExpression
     /// <param name="errors">Read-only span of errors.</param>
     /// <returns>Error or vale.</returns>
     /// <remarks>Enables support for collection expressions.</remarks>
-    public static ErrorOr<TValue> CreateErrorOr<TValue>(ReadOnlySpan<Error> errors)
-    {
-        return errors;
-    }
+    public static ErrorOr<TValue> CreateErrorOr<TValue>(ReadOnlySpan<Error> errors) => errors;
 
     /// <summary>
     /// Creates <see cref="IErrorOr{TValue}"/> from read-only span of errors.
@@ -24,10 +21,7 @@ public static class CollectionExpression
     /// <param name="errors">Read-only span of errors.</param>
     /// <returns>Error or vale.</returns>
     /// <remarks>Enables support for collection expressions.</remarks>
-    public static IErrorOr<TValue> CreateIErrorOrValue<TValue>(ReadOnlySpan<Error> errors)
-    {
-        return CreateErrorOr<TValue>(errors);
-    }
+    public static IErrorOr<TValue> CreateIErrorOrValue<TValue>(ReadOnlySpan<Error> errors) => CreateErrorOr<TValue>(errors);
 
     /// <summary>
     /// Creates <see cref="IErrorOr"/> from read-only span of errors.
@@ -35,8 +29,5 @@ public static class CollectionExpression
     /// <param name="errors">Read-only span of errors.</param>
     /// <returns>Error or vale.</returns>
     /// <remarks>Enables support for collection expressions.</remarks>
-    public static IErrorOr CreateIErrorOr(ReadOnlySpan<Error> errors)
-    {
-        return CreateErrorOr<object>(errors);
-    }
+    public static IErrorOr CreateIErrorOr(ReadOnlySpan<Error> errors) => CreateErrorOr<object>(errors);
 }

--- a/src/ErrorOr/ErrorOr.Else.cs
+++ b/src/ErrorOr/ErrorOr.Else.cs
@@ -7,7 +7,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// </summary>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original <see cref="Value"/>.</returns>
-    public ErrorOr<TValue> Else(Func<List<Error>, Error> onError)
+    public ErrorOr<TValue> Else(Func<ReadOnlyCollection<Error>, Error> onError)
     {
         if (IsSuccess)
         {
@@ -22,7 +22,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// </summary>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original <see cref="Value"/>.</returns>
-    public ErrorOr<TValue> Else(Func<List<Error>, List<Error>> onError)
+    public ErrorOr<TValue> Else(Func<ReadOnlyCollection<Error>, List<Error>> onError)
     {
         if (IsSuccess)
         {
@@ -52,7 +52,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// </summary>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original <see cref="Value"/>.</returns>
-    public ErrorOr<TValue> Else(Func<List<Error>, TValue> onError)
+    public ErrorOr<TValue> Else(Func<ReadOnlyCollection<Error>, TValue> onError)
     {
         if (IsSuccess)
         {
@@ -67,7 +67,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// </summary>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original <see cref="Value"/>.</returns>
-    public ErrorOr<TValue> Else(Func<List<Error>, ErrorOr<TValue>> onError)
+    public ErrorOr<TValue> Else(Func<ReadOnlyCollection<Error>, ErrorOr<TValue>> onError)
     {
         if (IsSuccess)
         {
@@ -97,7 +97,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// </summary>
     /// <param name="action">The action to execute if the state is error.</param>
     /// <returns>The original <see cref="ErrorOr"/> instance.</returns>
-    public ErrorOr<TValue> ElseDo(Action<List<Error>> action)
+    public ErrorOr<TValue> ElseDo(Action<ReadOnlyCollection<Error>> action)
     {
         if (IsSuccess)
         {
@@ -114,7 +114,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// </summary>
     /// <param name="action">The action to execute if the state is error.</param>
     /// <returns>The original <see cref="ErrorOr"/> instance.</returns>
-    public async Task<ErrorOr<TValue>> ElseDoAsync(Func<List<Error>, Task> action)
+    public async Task<ErrorOr<TValue>> ElseDoAsync(Func<ReadOnlyCollection<Error>, Task> action)
     {
         if (IsSuccess)
         {
@@ -131,7 +131,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// </summary>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original <see cref="Value"/>.</returns>
-    public async Task<ErrorOr<TValue>> ElseAsync(Func<List<Error>, Task<TValue>> onError)
+    public async Task<ErrorOr<TValue>> ElseAsync(Func<ReadOnlyCollection<Error>, Task<TValue>> onError)
     {
         if (IsSuccess)
         {
@@ -146,7 +146,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// </summary>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original <see cref="Value"/>.</returns>
-    public async Task<ErrorOr<TValue>> ElseAsync(Func<List<Error>, Task<ErrorOr<TValue>>> onError)
+    public async Task<ErrorOr<TValue>> ElseAsync(Func<ReadOnlyCollection<Error>, Task<ErrorOr<TValue>>> onError)
     {
         if (IsSuccess)
         {
@@ -161,7 +161,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// </summary>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original <see cref="Value"/>.</returns>
-    public async Task<ErrorOr<TValue>> ElseAsync(Func<List<Error>, Task<Error>> onError)
+    public async Task<ErrorOr<TValue>> ElseAsync(Func<ReadOnlyCollection<Error>, Task<Error>> onError)
     {
         if (IsSuccess)
         {
@@ -176,7 +176,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// </summary>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original <see cref="Value"/>.</returns>
-    public async Task<ErrorOr<TValue>> ElseAsync(Func<List<Error>, Task<List<Error>>> onError)
+    public async Task<ErrorOr<TValue>> ElseAsync(Func<ReadOnlyCollection<Error>, Task<List<Error>>> onError)
     {
         if (IsSuccess)
         {

--- a/src/ErrorOr/ErrorOr.Else.cs
+++ b/src/ErrorOr/ErrorOr.Else.cs
@@ -22,7 +22,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// </summary>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original <see cref="Value"/>.</returns>
-    public ErrorOr<TValue> Else(Func<ReadOnlyCollection<Error>, List<Error>> onError)
+    public ErrorOr<TValue> Else(Func<ReadOnlyCollection<Error>, ReadOnlyCollection<Error>> onError)
     {
         if (IsSuccess)
         {
@@ -176,7 +176,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// </summary>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original <see cref="Value"/>.</returns>
-    public async Task<ErrorOr<TValue>> ElseAsync(Func<ReadOnlyCollection<Error>, Task<List<Error>>> onError)
+    public async Task<ErrorOr<TValue>> ElseAsync(Func<ReadOnlyCollection<Error>, Task<ReadOnlyCollection<Error>>> onError)
     {
         if (IsSuccess)
         {

--- a/src/ErrorOr/ErrorOr.ElseExtensions.cs
+++ b/src/ErrorOr/ErrorOr.ElseExtensions.cs
@@ -107,7 +107,7 @@ public static partial class ErrorOrExtensions
     /// <param name="errorOr">The <see cref="ErrorOr"/> instance.</param>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original value.</returns>
-    public static async Task<ErrorOr<TValue>> Else<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<ReadOnlyCollection<Error>, List<Error>> onError)
+    public static async Task<ErrorOr<TValue>> Else<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<ReadOnlyCollection<Error>, ReadOnlyCollection<Error>> onError)
     {
         var result = await errorOr.ConfigureAwait(false);
 
@@ -149,7 +149,7 @@ public static partial class ErrorOrExtensions
     /// <param name="errorOr">The <see cref="ErrorOr"/> instance.</param>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original value.</returns>
-    public static async Task<ErrorOr<TValue>> ElseAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<ReadOnlyCollection<Error>, Task<List<Error>>> onError)
+    public static async Task<ErrorOr<TValue>> ElseAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<ReadOnlyCollection<Error>, Task<ReadOnlyCollection<Error>>> onError)
     {
         var result = await errorOr.ConfigureAwait(false);
 

--- a/src/ErrorOr/ErrorOr.ElseExtensions.cs
+++ b/src/ErrorOr/ErrorOr.ElseExtensions.cs
@@ -9,7 +9,7 @@ public static partial class ErrorOrExtensions
     /// <param name="errorOr">The <see cref="ErrorOr"/> instance.</param>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original value.</returns>
-    public static async Task<ErrorOr<TValue>> Else<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<List<Error>, TValue> onError)
+    public static async Task<ErrorOr<TValue>> Else<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<ReadOnlyCollection<Error>, TValue> onError)
     {
         var result = await errorOr.ConfigureAwait(false);
 
@@ -23,7 +23,7 @@ public static partial class ErrorOrExtensions
     /// <param name="errorOr">The <see cref="ErrorOr"/> instance.</param>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original value.</returns>
-    public static async Task<ErrorOr<TValue>> Else<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<List<Error>, ErrorOr<TValue>> onError)
+    public static async Task<ErrorOr<TValue>> Else<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<ReadOnlyCollection<Error>, ErrorOr<TValue>> onError)
     {
         var result = await errorOr.ConfigureAwait(false);
 
@@ -51,7 +51,7 @@ public static partial class ErrorOrExtensions
     /// <param name="errorOr">The <see cref="ErrorOr"/> instance.</param>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original value.</returns>
-    public static async Task<ErrorOr<TValue>> ElseAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<List<Error>, Task<TValue>> onError)
+    public static async Task<ErrorOr<TValue>> ElseAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<ReadOnlyCollection<Error>, Task<TValue>> onError)
     {
         var result = await errorOr.ConfigureAwait(false);
 
@@ -65,7 +65,7 @@ public static partial class ErrorOrExtensions
     /// <param name="errorOr">The <see cref="ErrorOr"/> instance.</param>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original value.</returns>
-    public static async Task<ErrorOr<TValue>> ElseAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<List<Error>, Task<ErrorOr<TValue>>> onError)
+    public static async Task<ErrorOr<TValue>> ElseAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<ReadOnlyCollection<Error>, Task<ErrorOr<TValue>>> onError)
     {
         var result = await errorOr.ConfigureAwait(false);
 
@@ -93,7 +93,7 @@ public static partial class ErrorOrExtensions
     /// <param name="errorOr">The <see cref="ErrorOr"/> instance.</param>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original value.</returns>
-    public static async Task<ErrorOr<TValue>> Else<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<List<Error>, Error> onError)
+    public static async Task<ErrorOr<TValue>> Else<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<ReadOnlyCollection<Error>, Error> onError)
     {
         var result = await errorOr.ConfigureAwait(false);
 
@@ -107,7 +107,7 @@ public static partial class ErrorOrExtensions
     /// <param name="errorOr">The <see cref="ErrorOr"/> instance.</param>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original value.</returns>
-    public static async Task<ErrorOr<TValue>> Else<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<List<Error>, List<Error>> onError)
+    public static async Task<ErrorOr<TValue>> Else<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<ReadOnlyCollection<Error>, List<Error>> onError)
     {
         var result = await errorOr.ConfigureAwait(false);
 
@@ -135,7 +135,7 @@ public static partial class ErrorOrExtensions
     /// <param name="errorOr">The <see cref="ErrorOr"/> instance.</param>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original value.</returns>
-    public static async Task<ErrorOr<TValue>> ElseAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<List<Error>, Task<Error>> onError)
+    public static async Task<ErrorOr<TValue>> ElseAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<ReadOnlyCollection<Error>, Task<Error>> onError)
     {
         var result = await errorOr.ConfigureAwait(false);
 
@@ -149,7 +149,7 @@ public static partial class ErrorOrExtensions
     /// <param name="errorOr">The <see cref="ErrorOr"/> instance.</param>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original value.</returns>
-    public static async Task<ErrorOr<TValue>> ElseAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<List<Error>, Task<List<Error>>> onError)
+    public static async Task<ErrorOr<TValue>> ElseAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<ReadOnlyCollection<Error>, Task<List<Error>>> onError)
     {
         var result = await errorOr.ConfigureAwait(false);
 
@@ -177,7 +177,7 @@ public static partial class ErrorOrExtensions
     /// <param name="errorOr">The <see cref="ErrorOr"/> instance.</param>
     /// <param name="action">The action to execute if the state is error.</param>
     /// <returns>The original <paramref name="errorOr"/>.</returns>
-    public static async Task<ErrorOr<TValue>> ElseDo<TValue>(this Task<ErrorOr<TValue>> errorOr, Action<List<Error>> action)
+    public static async Task<ErrorOr<TValue>> ElseDo<TValue>(this Task<ErrorOr<TValue>> errorOr, Action<ReadOnlyCollection<Error>> action)
     {
         var result = await errorOr.ConfigureAwait(false);
 
@@ -191,7 +191,7 @@ public static partial class ErrorOrExtensions
     /// <param name="errorOr">The <see cref="ErrorOr"/> instance.</param>
     /// <param name="action">The action to execute if the state is error.</param>
     /// <returns>The original <paramref name="errorOr"/>.</returns>
-    public static async Task<ErrorOr<TValue>> ElseDoAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<List<Error>, Task> action)
+    public static async Task<ErrorOr<TValue>> ElseDoAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<ReadOnlyCollection<Error>, Task> action)
     {
         var result = await errorOr.ConfigureAwait(false);
 

--- a/src/ErrorOr/ErrorOr.Equality.cs
+++ b/src/ErrorOr/ErrorOr.Equality.cs
@@ -30,7 +30,7 @@ public readonly partial record struct ErrorOr<TValue>
         return hashCode.ToHashCode();
     }
 
-    private static bool CheckIfErrorsAreEqual(List<Error> errors1, List<Error> errors2)
+    private static bool CheckIfErrorsAreEqual(ReadOnlyCollection<Error> errors1, ReadOnlyCollection<Error> errors2)
     {
         // This method is currently implemented with strict ordering in mind, so the errors
         // of the two lists need to be in the exact same order.

--- a/src/ErrorOr/ErrorOr.ImplicitConverters.cs
+++ b/src/ErrorOr/ErrorOr.ImplicitConverters.cs
@@ -13,12 +13,17 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     public static implicit operator ErrorOr<TValue>(Error error) => new(error);
 
     /// <summary>
-    /// Creates an <see cref="ErrorOr{TValue}"/> from a list of errors.
+    /// Creates an <see cref="ErrorOr{TValue}"/> from a read-only list of errors.
     /// </summary>
-    public static implicit operator ErrorOr<TValue>(List<Error> errors) => errors?.Count > 0 ? new(errors) : new(KnownErrors.CachedInvalidInitialErrorsList);
+    public static implicit operator ErrorOr<TValue>(ReadOnlyCollection<Error> errors) => errors?.Count > 0 ? new(errors) : new(KnownErrors.CachedInvalidInitialErrorsList);
+
+    /// <summary>
+    /// Creates an <see cref="ErrorOr{TValue}"/> from a read-only span of errors.
+    /// </summary>
+    public static implicit operator ErrorOr<TValue>(ReadOnlySpan<Error> errors) => errors.Length > 0 ? new(new ReadOnlyCollection<Error>([.. errors])) : new(KnownErrors.CachedInvalidInitialErrorsList);
 
     /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> from a list of errors.
     /// </summary>
-    public static implicit operator ErrorOr<TValue>(Error[] errors) => errors?.Length > 0 ? new([.. errors]) : new(KnownErrors.CachedInvalidInitialErrorsList);
+    public static implicit operator ErrorOr<TValue>(List<Error> errors) => errors?.Count > 0 ? new(new ReadOnlyCollection<Error>([.. errors])) : new(KnownErrors.CachedInvalidInitialErrorsList);
 }

--- a/src/ErrorOr/ErrorOr.ImplicitConverters.cs
+++ b/src/ErrorOr/ErrorOr.ImplicitConverters.cs
@@ -15,15 +15,15 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> from a read-only list of errors.
     /// </summary>
-    public static implicit operator ErrorOr<TValue>(ReadOnlyCollection<Error> errors) => errors?.Count > 0 ? new(errors) : new(KnownErrors.CachedInvalidInitialErrorsList);
+    public static implicit operator ErrorOr<TValue>(ReadOnlyCollection<Error> errors) => errors?.Count > 0 ? new(Array.AsReadOnly([.. errors])) : new(KnownErrors.CachedInvalidInitialErrorsList);
 
     /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> from a read-only span of errors.
     /// </summary>
-    public static implicit operator ErrorOr<TValue>(ReadOnlySpan<Error> errors) => errors.Length > 0 ? new(new ReadOnlyCollection<Error>([.. errors])) : new(KnownErrors.CachedInvalidInitialErrorsList);
+    public static implicit operator ErrorOr<TValue>(ReadOnlySpan<Error> errors) => errors.Length > 0 ? new(Array.AsReadOnly([.. errors])) : new(KnownErrors.CachedInvalidInitialErrorsList);
 
     /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> from a list of errors.
     /// </summary>
-    public static implicit operator ErrorOr<TValue>(List<Error> errors) => errors?.Count > 0 ? new(new ReadOnlyCollection<Error>([.. errors])) : new(KnownErrors.CachedInvalidInitialErrorsList);
+    public static implicit operator ErrorOr<TValue>(List<Error> errors) => errors?.Count > 0 ? new(Array.AsReadOnly([.. errors])) : new(KnownErrors.CachedInvalidInitialErrorsList);
 }

--- a/src/ErrorOr/ErrorOr.Match.cs
+++ b/src/ErrorOr/ErrorOr.Match.cs
@@ -11,7 +11,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// <param name="onValue">The function to execute if the state is a value.</param>
     /// <param name="onError">The function to execute if the state is an error.</param>
     /// <returns>The result of the executed function.</returns>
-    public TNextValue Match<TNextValue>(Func<TValue, TNextValue> onValue, Func<List<Error>, TNextValue> onError)
+    public TNextValue Match<TNextValue>(Func<TValue, TNextValue> onValue, Func<ReadOnlyCollection<Error>, TNextValue> onError)
     {
         if (IsError)
         {
@@ -30,7 +30,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// <param name="onValue">The asynchronous function to execute if the state is a value.</param>
     /// <param name="onError">The asynchronous function to execute if the state is an error.</param>
     /// <returns>A task representing the asynchronous operation that yields the result of the executed function.</returns>
-    public async Task<TNextValue> MatchAsync<TNextValue>(Func<TValue, Task<TNextValue>> onValue, Func<List<Error>, Task<TNextValue>> onError)
+    public async Task<TNextValue> MatchAsync<TNextValue>(Func<TValue, Task<TNextValue>> onValue, Func<ReadOnlyCollection<Error>, Task<TNextValue>> onError)
     {
         if (IsError)
         {

--- a/src/ErrorOr/ErrorOr.MatchExtensions.cs
+++ b/src/ErrorOr/ErrorOr.MatchExtensions.cs
@@ -13,7 +13,7 @@ public static partial class ErrorOrExtensions
     /// <param name="onValue">The function to execute if the state is a value.</param>
     /// <param name="onError">The function to execute if the state is an error.</param>
     /// <returns>The result of the executed function.</returns>
-    public static async Task<TNextValue> Match<TValue, TNextValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, TNextValue> onValue, Func<List<Error>, TNextValue> onError)
+    public static async Task<TNextValue> Match<TValue, TNextValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, TNextValue> onValue, Func<ReadOnlyCollection<Error>, TNextValue> onError)
     {
         var result = await errorOr.ConfigureAwait(false);
 
@@ -31,7 +31,7 @@ public static partial class ErrorOrExtensions
     /// <param name="onValue">The function to execute if the state is a value.</param>
     /// <param name="onError">The function to execute if the state is an error.</param>
     /// <returns>The result of the executed function.</returns>
-    public static async Task<TNextValue> MatchAsync<TValue, TNextValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task<TNextValue>> onValue, Func<List<Error>, Task<TNextValue>> onError)
+    public static async Task<TNextValue> MatchAsync<TValue, TNextValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task<TNextValue>> onValue, Func<ReadOnlyCollection<Error>, Task<TNextValue>> onError)
     {
         var result = await errorOr.ConfigureAwait(false);
 

--- a/src/ErrorOr/ErrorOr.Switch.cs
+++ b/src/ErrorOr/ErrorOr.Switch.cs
@@ -9,7 +9,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// </summary>
     /// <param name="onValue">The action to execute if the state is a value.</param>
     /// <param name="onError">The action to execute if the state is an error.</param>
-    public void Switch(Action<TValue> onValue, Action<List<Error>> onError)
+    public void Switch(Action<TValue> onValue, Action<ReadOnlyCollection<Error>> onError)
     {
         if (IsError)
         {
@@ -28,7 +28,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// <param name="onValue">The asynchronous action to execute if the state is a value.</param>
     /// <param name="onError">The asynchronous action to execute if the state is an error.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public async Task SwitchAsync(Func<TValue, Task> onValue, Func<List<Error>, Task> onError)
+    public async Task SwitchAsync(Func<TValue, Task> onValue, Func<ReadOnlyCollection<Error>, Task> onError)
     {
         if (IsError)
         {

--- a/src/ErrorOr/ErrorOr.SwitchExtensions.cs
+++ b/src/ErrorOr/ErrorOr.SwitchExtensions.cs
@@ -12,7 +12,7 @@ public static partial class ErrorOrExtensions
     /// <param name="onValue">The action to execute if the state is a value.</param>
     /// <param name="onError">The action to execute if the state is an error.</param>
     /// <returns>The result of the executed function.</returns>
-    public static async Task Switch<TValue>(this Task<ErrorOr<TValue>> errorOr, Action<TValue> onValue, Action<List<Error>> onError)
+    public static async Task Switch<TValue>(this Task<ErrorOr<TValue>> errorOr, Action<TValue> onValue, Action<ReadOnlyCollection<Error>> onError)
     {
         var result = await errorOr.ConfigureAwait(false);
 
@@ -29,7 +29,7 @@ public static partial class ErrorOrExtensions
     /// <param name="onValue">The action to execute if the state is a value.</param>
     /// <param name="onError">The action to execute if the state is an error.</param>
     /// <returns>The result of the executed function.</returns>
-    public static async Task SwitchAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task> onValue, Func<List<Error>, Task> onError)
+    public static async Task SwitchAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task> onValue, Func<ReadOnlyCollection<Error>, Task> onError)
     {
         var result = await errorOr.ConfigureAwait(false);
 

--- a/src/ErrorOr/ErrorOr.ToErrorOrExtensions.cs
+++ b/src/ErrorOr/ErrorOr.ToErrorOrExtensions.cs
@@ -54,7 +54,7 @@ public static partial class ErrorOrExtensions
     /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given enumeration of errors.
     /// </summary>
     /// <param name="errors">The enumeration of errors to create the <see cref="ErrorOr{TValue}"/> instance with.</param>
-    public static ErrorOr<TValue> ToErrorOr<TValue>(this IEnumerable<Error> errors) => errors.ToList();
+    public static ErrorOr<TValue> ToErrorOr<TValue>(this IEnumerable<Error> errors) => errors.ToArray();
 
     /// <summary>
     /// Creates an awaitable <see cref="ErrorOr{TValue}"/> instance with the given awaitable array of errors.
@@ -69,6 +69,6 @@ public static partial class ErrorOrExtensions
     public static async Task<ErrorOr<TValue>> ToErrorOrAsync<TValue>(this Task<IEnumerable<Error>> errors)
     {
         var errorEnumeration = await errors.ConfigureAwait(false);
-        return errorEnumeration.ToList();
+        return errorEnumeration.ToArray();
     }
 }

--- a/src/ErrorOr/ErrorOr.ToErrorOrExtensions.cs
+++ b/src/ErrorOr/ErrorOr.ToErrorOrExtensions.cs
@@ -6,91 +6,61 @@ public static partial class ErrorOrExtensions
     /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given value.
     /// </summary>
     /// <param name="value">The value to create the <see cref="ErrorOr{TValue}"/> instance with.</param>
-    public static ErrorOr<TValue> ToErrorOr<TValue>(this TValue value)
-    {
-        return value;
-    }
+    public static ErrorOr<TValue> ToErrorOr<TValue>(this TValue value) => value;
 
     /// <summary>
     /// Creates an awaitable <see cref="ErrorOr{TValue}"/> instance with the result of the given awaitable value.
     /// </summary>
     /// <param name="value">The awaitable value to create the <see cref="ErrorOr{TValue}"/> instance with.</param>
-    public static async Task<ErrorOr<TValue>> ToErrorOrAsync<TValue>(this Task<TValue> value)
-    {
-        return await value.ConfigureAwait(false);
-    }
+    public static async Task<ErrorOr<TValue>> ToErrorOrAsync<TValue>(this Task<TValue> value) => await value.ConfigureAwait(false);
 
     /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given error.
     /// </summary>
     /// <param name="error">The error to create the <see cref="ErrorOr{TValue}"/> instance with.</param>
-    public static ErrorOr<TValue> ToErrorOr<TValue>(this Error error)
-    {
-        return error;
-    }
+    public static ErrorOr<TValue> ToErrorOr<TValue>(this Error error) => error;
 
     /// <summary>
     /// Creates an awaitable <see cref="ErrorOr{TValue}"/> instance with the given awaitable error.
     /// </summary>
     /// <param name="error">The awaitable error to create the <see cref="ErrorOr{TValue}"/> instance with.</param>
-    public static async Task<ErrorOr<TValue>> ToErrorOrAsync<TValue>(this Task<Error> error)
-    {
-        return await error.ConfigureAwait(false);
-    }
+    public static async Task<ErrorOr<TValue>> ToErrorOrAsync<TValue>(this Task<Error> error) => await error.ConfigureAwait(false);
 
     /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given read-only list of errors.
     /// </summary>
     /// <param name="errors">The read-only list of errors to create the <see cref="ErrorOr{TValue}"/> instance with.</param>
-    public static ErrorOr<TValue> ToErrorOr<TValue>(this ReadOnlyCollection<Error> errors)
-    {
-        return errors;
-    }
+    public static ErrorOr<TValue> ToErrorOr<TValue>(this ReadOnlyCollection<Error> errors) => errors;
 
     /// <summary>
     /// Creates an awaitable <see cref="ErrorOr{TValue}"/> instance with the given awaitable read-only list of errors.
     /// </summary>
     /// <param name="errors">The awaitable read-only list of errors to create the <see cref="ErrorOr{TValue}"/> instance with.</param>
-    public static async Task<ErrorOr<TValue>> ToErrorOrAsync<TValue>(this Task<ReadOnlyCollection<Error>> errors)
-    {
-        return await errors.ConfigureAwait(false);
-    }
+    public static async Task<ErrorOr<TValue>> ToErrorOrAsync<TValue>(this Task<ReadOnlyCollection<Error>> errors) => await errors.ConfigureAwait(false);
 
     /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given list of errors.
     /// </summary>
     /// <param name="errors">The list of errors to create the <see cref="ErrorOr{TValue}"/> instance with.</param>
-    public static ErrorOr<TValue> ToErrorOr<TValue>(this List<Error> errors)
-    {
-        return errors;
-    }
+    public static ErrorOr<TValue> ToErrorOr<TValue>(this List<Error> errors) => errors;
 
     /// <summary>
     /// Creates an awaitable <see cref="ErrorOr{TValue}"/> instance with the given awaitable list of errors.
     /// </summary>
     /// <param name="errors">The awaitable list of errors to create the <see cref="ErrorOr{TValue}"/> instance with.</param>
-    public static async Task<ErrorOr<TValue>> ToErrorOrAsync<TValue>(this Task<List<Error>> errors)
-    {
-        return await errors.ConfigureAwait(false);
-    }
+    public static async Task<ErrorOr<TValue>> ToErrorOrAsync<TValue>(this Task<List<Error>> errors) => await errors.ConfigureAwait(false);
 
     /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given enumeration of errors.
     /// </summary>
     /// <param name="errors">The enumeration of errors to create the <see cref="ErrorOr{TValue}"/> instance with.</param>
-    public static ErrorOr<TValue> ToErrorOr<TValue>(this IEnumerable<Error> errors)
-    {
-        return errors.ToList();
-    }
+    public static ErrorOr<TValue> ToErrorOr<TValue>(this IEnumerable<Error> errors) => errors.ToList();
 
     /// <summary>
     /// Creates an awaitable <see cref="ErrorOr{TValue}"/> instance with the given awaitable array of errors.
     /// </summary>
     /// <param name="errors">The awaitable array of errors to create the <see cref="ErrorOr{TValue}"/> instance with.</param>
-    public static async Task<ErrorOr<TValue>> ToErrorOrAsync<TValue>(this Task<Error[]> errors)
-    {
-        return await errors.ConfigureAwait(false);
-    }
+    public static async Task<ErrorOr<TValue>> ToErrorOrAsync<TValue>(this Task<Error[]> errors) => await errors.ConfigureAwait(false);
 
     /// <summary>
     /// Creates an awaitable <see cref="ErrorOr{TValue}"/> instance with the given awaitable enumeration of errors.

--- a/src/ErrorOr/ErrorOr.ToErrorOrExtensions.cs
+++ b/src/ErrorOr/ErrorOr.ToErrorOrExtensions.cs
@@ -39,6 +39,24 @@ public static partial class ErrorOrExtensions
     }
 
     /// <summary>
+    /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given read-only list of errors.
+    /// </summary>
+    /// <param name="errors">The read-only list of errors to create the <see cref="ErrorOr{TValue}"/> instance with.</param>
+    public static ErrorOr<TValue> ToErrorOr<TValue>(this ReadOnlyCollection<Error> errors)
+    {
+        return errors;
+    }
+
+    /// <summary>
+    /// Creates an awaitable <see cref="ErrorOr{TValue}"/> instance with the given awaitable read-only list of errors.
+    /// </summary>
+    /// <param name="errors">The awaitable read-only list of errors to create the <see cref="ErrorOr{TValue}"/> instance with.</param>
+    public static async Task<ErrorOr<TValue>> ToErrorOrAsync<TValue>(this Task<ReadOnlyCollection<Error>> errors)
+    {
+        return await errors.ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given list of errors.
     /// </summary>
     /// <param name="errors">The list of errors to create the <see cref="ErrorOr{TValue}"/> instance with.</param>
@@ -68,17 +86,16 @@ public static partial class ErrorOrExtensions
     /// <summary>
     /// Creates an awaitable <see cref="ErrorOr{TValue}"/> instance with the given awaitable array of errors.
     /// </summary>
-    /// <param name="errors">The array of errors to create the <see cref="ErrorOr{TValue}"/> instance with.</param>
+    /// <param name="errors">The awaitable array of errors to create the <see cref="ErrorOr{TValue}"/> instance with.</param>
     public static async Task<ErrorOr<TValue>> ToErrorOrAsync<TValue>(this Task<Error[]> errors)
     {
-        var errorArray = await errors.ConfigureAwait(false);
-        return errorArray.ToList();
+        return await errors.ConfigureAwait(false);
     }
 
     /// <summary>
     /// Creates an awaitable <see cref="ErrorOr{TValue}"/> instance with the given awaitable enumeration of errors.
     /// </summary>
-    /// <param name="errors">The enumeration of errors to create the <see cref="ErrorOr{TValue}"/> instance with.</param>
+    /// <param name="errors">The awaitable enumeration of errors to create the <see cref="ErrorOr{TValue}"/> instance with.</param>
     public static async Task<ErrorOr<TValue>> ToErrorOrAsync<TValue>(this Task<IEnumerable<Error>> errors)
     {
         var errorEnumeration = await errors.ConfigureAwait(false);

--- a/src/ErrorOr/ErrorOr.cs
+++ b/src/ErrorOr/ErrorOr.cs
@@ -11,13 +11,13 @@ namespace ErrorOr;
 public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
 {
     private readonly TValue? _value = default;
-    private readonly List<Error>? _errors = null;
+    private readonly ReadOnlyCollection<Error>? _errors = null;
 
     private ErrorOr(TValue value) => _value = value;
 
-    private ErrorOr(Error error) => _errors = [error];
+    private ErrorOr(Error error) => _errors = new ReadOnlyCollection<Error>([error]);
 
-    private ErrorOr(List<Error> errors) => _errors = errors?.Count == 0 ? null : errors;
+    private ErrorOr(ReadOnlyCollection<Error> errors) => _errors = errors;
 
     /// <summary>
     /// Gets a value indicating whether the state is error.
@@ -40,12 +40,12 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// <summary>
     /// Gets the list of errors. If the state is not error, the list will contain a single error representing the state.
     /// </summary>
-    public List<Error> Errors => IsError ? _errors : KnownErrors.CachedNoErrorsList;
+    public ReadOnlyCollection<Error> Errors => IsError ? _errors : KnownErrors.CachedNoErrorsList;
 
     /// <summary>
     /// Gets the list of errors. If the state is not error, the list will be empty.
     /// </summary>
-    public List<Error> ErrorsOrEmptyList => IsError ? _errors : KnownErrors.CachedEmptyErrorsList;
+    public ReadOnlyCollection<Error> ErrorsOrEmptyList => IsError ? _errors : KnownErrors.CachedEmptyErrorsList;
 
     /// <summary>
     /// Gets the value.
@@ -70,10 +70,4 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
 
     /// <inheritdoc/>
     public IEnumerator<Error> GetEnumerator() => _errors!.GetEnumerator();
-
-    /// <summary>
-    /// Creates an <see cref="ErrorOr{TValue}"/> from a list of errors.
-    /// </summary>
-    [Obsolete("ErrorOrFactory.From<TValue>(errors) should be used instead.")]
-    public static ErrorOr<TValue> From(List<Error> errors) => errors;
 }

--- a/src/ErrorOr/ErrorOr.cs
+++ b/src/ErrorOr/ErrorOr.cs
@@ -15,7 +15,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
 
     private ErrorOr(TValue value) => _value = value;
 
-    private ErrorOr(Error error) => _errors = new ReadOnlyCollection<Error>([error]);
+    private ErrorOr(Error error) => _errors = Array.AsReadOnly([error]);
 
     private ErrorOr(ReadOnlyCollection<Error> errors) => _errors = errors;
 

--- a/src/ErrorOr/ErrorOrFactory.cs
+++ b/src/ErrorOr/ErrorOrFactory.cs
@@ -50,45 +50,23 @@ public static class ErrorOrFactory
     }
 
     /// <summary>
-    /// Creates an <see cref="ErrorOr{TValue}"/> from a list of errors.
+    /// Creates an <see cref="ErrorOr{TValue}"/> from a read-only span of errors.
     /// </summary>
     /// <typeparam name="TValue">The type of the value.</typeparam>
-    /// <param name="errors">List of errors.</param>
-    /// <returns>An instance of <see cref="ErrorOr{TValue}"/> containing provided list of errors.</returns>
-    public static ErrorOr<TValue> From<TValue>(List<Error> errors)
+    /// <param name="errors">Read-only span of errors.</param>
+    /// <returns>An instance of <see cref="ErrorOr{TValue}"/> containing provided read-only span of errors.</returns>
+    public static ErrorOr<TValue> From<TValue>(ReadOnlySpan<Error> errors)
     {
-        return errors;
+        return errors.ToArray();
     }
 
     /// <summary>
-    /// Creates an awaitable instance of<see cref="ErrorOr{TValue}"/> from a list of errors.
+    /// Creates an awaitable instance of<see cref="ErrorOr{TValue}"/> from a read-only span of errors.
     /// </summary>
     /// <typeparam name="TValue">The type of the value.</typeparam>
-    /// <param name="errors">List of errors.</param>
-    /// <returns>An awaitable instance of <see cref="ErrorOr{TValue}"/> containing provided list of errors.</returns>
-    public static Task<ErrorOr<TValue>> FromAsync<TValue>(List<Error> errors)
-    {
-        return Task.FromResult(From<TValue>(errors));
-    }
-
-    /// <summary>
-    /// Creates an <see cref="ErrorOr{TValue}"/> from an enumeration of errors.
-    /// </summary>
-    /// <typeparam name="TValue">The type of the value.</typeparam>
-    /// <param name="errors">Enumeration of errors.</param>
-    /// <returns>An instance of <see cref="ErrorOr{TValue}"/> containing provided enumeration of errors.</returns>
-    public static ErrorOr<TValue> From<TValue>(IEnumerable<Error> errors)
-    {
-        return errors.ToList();
-    }
-
-    /// <summary>
-    /// Creates an awaitable instance of<see cref="ErrorOr{TValue}"/> from an enumeration of errors.
-    /// </summary>
-    /// <typeparam name="TValue">The type of the value.</typeparam>
-    /// <param name="errors">Enumeration of errors.</param>
-    /// <returns>An awaitable instance of <see cref="ErrorOr{TValue}"/> containing provided enumeration of errors.</returns>
-    public static Task<ErrorOr<TValue>> FromAsync<TValue>(IEnumerable<Error> errors)
+    /// <param name="errors">Read-only span of errors.</param>
+    /// <returns>An awaitable instance of <see cref="ErrorOr{TValue}"/> containing provided read-only span of errors.</returns>
+    public static Task<ErrorOr<TValue>> FromAsync<TValue>(ReadOnlySpan<Error> errors)
     {
         return Task.FromResult(From<TValue>(errors));
     }

--- a/src/ErrorOr/ErrorOrFactory.cs
+++ b/src/ErrorOr/ErrorOrFactory.cs
@@ -11,10 +11,7 @@ public static class ErrorOrFactory
     /// <typeparam name="TValue">The type of the value.</typeparam>
     /// <param name="value">The value to wrap.</param>
     /// <returns>An instance of <see cref="ErrorOr{TValue}"/> containing the provided value.</returns>
-    public static ErrorOr<TValue> From<TValue>(TValue value)
-    {
-        return value;
-    }
+    public static ErrorOr<TValue> From<TValue>(TValue value) => value;
 
     /// <summary>
     /// Creates a new awaitable instance of <see cref="ErrorOr{TValue}"/> from value.
@@ -22,10 +19,7 @@ public static class ErrorOrFactory
     /// <typeparam name="TValue">The type of the value.</typeparam>
     /// <param name="value">The value to wrap.</param>
     /// <returns>An awaitable instance of <see cref="ErrorOr{TValue}"/> containing provided value.</returns>
-    public static Task<ErrorOr<TValue>> FromAsync<TValue>(TValue value)
-    {
-        return Task.FromResult(From(value));
-    }
+    public static Task<ErrorOr<TValue>> FromAsync<TValue>(TValue value) => Task.FromResult(From(value));
 
     /// <summary>
     /// Creates a new instance of <see cref="ErrorOr{TValue}"/> from single error.
@@ -33,10 +27,7 @@ public static class ErrorOrFactory
     /// <typeparam name="TValue">The type of the value.</typeparam>
     /// <param name="error">Single error instance to wrap.</param>
     /// <returns>An instance of <see cref="ErrorOr{TValue}"/> containing the provided error.</returns>
-    public static ErrorOr<TValue> From<TValue>(Error error)
-    {
-        return error;
-    }
+    public static ErrorOr<TValue> From<TValue>(Error error) => error;
 
     /// <summary>
     /// Creates a new awaitable instance of <see cref="ErrorOr{TValue}"/> from single error.
@@ -44,10 +35,7 @@ public static class ErrorOrFactory
     /// <typeparam name="TValue">The type of the value.</typeparam>
     /// <param name="error">Single error instance to wrap.</param>
     /// <returns>An awaitable instance of <see cref="ErrorOr{TValue}"/> containing the provided error.</returns>
-    public static Task<ErrorOr<TValue>> FromAsync<TValue>(Error error)
-    {
-        return Task.FromResult(From<TValue>(error));
-    }
+    public static Task<ErrorOr<TValue>> FromAsync<TValue>(Error error) => Task.FromResult(From<TValue>(error));
 
     /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> from a read-only span of errors.
@@ -55,10 +43,7 @@ public static class ErrorOrFactory
     /// <typeparam name="TValue">The type of the value.</typeparam>
     /// <param name="errors">Read-only span of errors.</param>
     /// <returns>An instance of <see cref="ErrorOr{TValue}"/> containing provided read-only span of errors.</returns>
-    public static ErrorOr<TValue> From<TValue>(ReadOnlySpan<Error> errors)
-    {
-        return errors.ToArray();
-    }
+    public static ErrorOr<TValue> From<TValue>(ReadOnlySpan<Error> errors) => errors.ToArray();
 
     /// <summary>
     /// Creates an awaitable instance of<see cref="ErrorOr{TValue}"/> from a read-only span of errors.
@@ -66,8 +51,5 @@ public static class ErrorOrFactory
     /// <typeparam name="TValue">The type of the value.</typeparam>
     /// <param name="errors">Read-only span of errors.</param>
     /// <returns>An awaitable instance of <see cref="ErrorOr{TValue}"/> containing provided read-only span of errors.</returns>
-    public static Task<ErrorOr<TValue>> FromAsync<TValue>(ReadOnlySpan<Error> errors)
-    {
-        return Task.FromResult(From<TValue>(errors));
-    }
+    public static Task<ErrorOr<TValue>> FromAsync<TValue>(ReadOnlySpan<Error> errors) => Task.FromResult(From<TValue>(errors));
 }

--- a/src/ErrorOr/ErrorOrFactory.cs
+++ b/src/ErrorOr/ErrorOrFactory.cs
@@ -43,7 +43,7 @@ public static class ErrorOrFactory
     /// <typeparam name="TValue">The type of the value.</typeparam>
     /// <param name="errors">Read-only span of errors.</param>
     /// <returns>An instance of <see cref="ErrorOr{TValue}"/> containing provided read-only span of errors.</returns>
-    public static ErrorOr<TValue> From<TValue>(ReadOnlySpan<Error> errors) => errors.ToArray();
+    public static ErrorOr<TValue> From<TValue>(ReadOnlySpan<Error> errors) => errors;
 
     /// <summary>
     /// Creates an awaitable instance of<see cref="ErrorOr{TValue}"/> from a read-only span of errors.

--- a/src/ErrorOr/IErrorOr.cs
+++ b/src/ErrorOr/IErrorOr.cs
@@ -23,7 +23,7 @@ public interface IErrorOr : IRecordable
     /// <summary>
     /// Gets the list of errors.
     /// </summary>
-    List<Error>? Errors { get; }
+    ReadOnlyCollection<Error>? Errors { get; }
 
     /// <summary>
     /// Gets a value indicating whether the state is error.

--- a/src/ErrorOr/IRecordingSerializer.cs
+++ b/src/ErrorOr/IRecordingSerializer.cs
@@ -1,4 +1,4 @@
-﻿namespace ErrorOr;
+namespace ErrorOr;
 
 /// <summary>
 /// Defines a serialization strategy for recording the state of an <see cref="ErrorOr{TValue}"/> instance
@@ -25,5 +25,5 @@ public interface IRecordingSerializer<TOutput>
     /// </summary>
     /// <param name="errors">The list of errors to serialize.</param>
     /// <returns>A <typeparamref name="TOutput"/> representation of <paramref name="errors"/>.</returns>
-    TOutput SerializeErrors(List<Error> errors);
+    TOutput SerializeErrors(ReadOnlyCollection<Error> errors);
 }

--- a/src/Errors/Error.cs
+++ b/src/Errors/Error.cs
@@ -1,3 +1,6 @@
+using Dict = System.Collections.Generic.Dictionary<string, object>;
+using ReadDict = System.Collections.ObjectModel.ReadOnlyDictionary<string, object>;
+
 namespace ErrorOr;
 
 /// <summary>
@@ -5,13 +8,15 @@ namespace ErrorOr;
 /// </summary>
 public readonly record struct Error
 {
-    private Error(string code, string description, ErrorType type, Dictionary<string, object>? metadata)
+    private Error(string code, string description, ErrorType type, IDictionary<string, object>? metadata)
     {
         Code = code;
         Description = description;
         Type = type;
-        NumericType = (int)type;
-        Metadata = metadata;
+        if (metadata is not null)
+        {
+            Metadata = new ReadDict(new Dict(metadata));
+        }
     }
 
     /// <summary>
@@ -32,12 +37,12 @@ public readonly record struct Error
     /// <summary>
     /// Gets the numeric value of the type.
     /// </summary>
-    public int NumericType { get; }
+    public int NumericType => (int)Type;
 
     /// <summary>
     /// Gets the metadata.
     /// </summary>
-    public Dictionary<string, object>? Metadata { get; }
+    public ReadDict? Metadata { get; }
 
     /// <summary>
     /// Creates an <see cref="Error"/> of type <see cref="ErrorType.Failure"/> from a code and description.
@@ -48,7 +53,7 @@ public readonly record struct Error
     public static Error Failure(
         string code = "General.Failure",
         string description = "A failure has occurred.",
-        Dictionary<string, object>? metadata = null) =>
+        IDictionary<string, object>? metadata = null) =>
             new(code, description, ErrorType.Failure, metadata);
 
     /// <summary>
@@ -60,7 +65,7 @@ public readonly record struct Error
     public static Error Unexpected(
         string code = "General.Unexpected",
         string description = "An unexpected error has occurred.",
-        Dictionary<string, object>? metadata = null) =>
+        IDictionary<string, object>? metadata = null) =>
             new(code, description, ErrorType.Unexpected, metadata);
 
     /// <summary>
@@ -72,7 +77,7 @@ public readonly record struct Error
     public static Error Validation(
         string code = "General.Validation",
         string description = "A validation error has occurred.",
-        Dictionary<string, object>? metadata = null) =>
+        IDictionary<string, object>? metadata = null) =>
             new(code, description, ErrorType.Validation, metadata);
 
     /// <summary>
@@ -84,7 +89,7 @@ public readonly record struct Error
     public static Error Conflict(
         string code = "General.Conflict",
         string description = "A conflict error has occurred.",
-        Dictionary<string, object>? metadata = null) =>
+        IDictionary<string, object>? metadata = null) =>
             new(code, description, ErrorType.Conflict, metadata);
 
     /// <summary>
@@ -96,7 +101,7 @@ public readonly record struct Error
     public static Error NotFound(
         string code = "General.NotFound",
         string description = "A 'Not Found' error has occurred.",
-        Dictionary<string, object>? metadata = null) =>
+        IDictionary<string, object>? metadata = null) =>
             new(code, description, ErrorType.NotFound, metadata);
 
     /// <summary>
@@ -108,7 +113,7 @@ public readonly record struct Error
     public static Error Unauthorized(
         string code = "General.Unauthorized",
         string description = "An 'Unauthorized' error has occurred.",
-        Dictionary<string, object>? metadata = null) =>
+        IDictionary<string, object>? metadata = null) =>
             new(code, description, ErrorType.Unauthorized, metadata);
 
     /// <summary>
@@ -120,7 +125,7 @@ public readonly record struct Error
     public static Error Forbidden(
         string code = "General.Forbidden",
         string description = "A 'Forbidden' error has occurred.",
-        Dictionary<string, object>? metadata = null) =>
+        IDictionary<string, object>? metadata = null) =>
         new(code, description, ErrorType.Forbidden, metadata);
 
     /// <summary>
@@ -135,7 +140,7 @@ public readonly record struct Error
         int type,
         string code,
         string description,
-        Dictionary<string, object>? metadata = null) =>
+        IDictionary<string, object>? metadata = null) =>
             new(code, description, (ErrorType)type, metadata);
 
     public bool Equals(Error other)
@@ -153,7 +158,7 @@ public readonly record struct Error
             return other.Metadata is null;
         }
 
-        return other.Metadata is not null && CompareMetadata(Metadata, other.Metadata);
+        return other.Metadata is not null && CompareMetadata(Metadata!, other.Metadata);
     }
 
     public override int GetHashCode() =>
@@ -179,7 +184,7 @@ public readonly record struct Error
         return hashCode.ToHashCode();
     }
 
-    private static bool CompareMetadata(Dictionary<string, object> metadata, Dictionary<string, object> otherMetadata)
+    private static bool CompareMetadata(ReadDict metadata, ReadDict otherMetadata)
     {
         if (ReferenceEquals(metadata, otherMetadata))
         {

--- a/src/Errors/KnownErrors.cs
+++ b/src/Errors/KnownErrors.cs
@@ -18,5 +18,10 @@ internal static class KnownErrors
 
     public static ReadOnlyCollection<Error> CachedInvalidInitialErrorsList { get; } = new ReadOnlyCollection<Error>([EmptyInitialErrors]);
 
+#if NETSTANDARD
     public static ReadOnlyCollection<Error> CachedEmptyErrorsList { get; } = new ReadOnlyCollection<Error>([]);
+#else
+    public static ReadOnlyCollection<Error> CachedEmptyErrorsList { get; } = ReadOnlyCollection<Error>.Empty;
+#endif
+
 }

--- a/src/Errors/KnownErrors.cs
+++ b/src/Errors/KnownErrors.cs
@@ -14,12 +14,12 @@ internal static class KnownErrors
         code: "ErrorOr.EmptyInitialErrors",
         description: "Error list cannot be null or empty when initializing ErrorOr.");
 
-    public static ReadOnlyCollection<Error> CachedNoErrorsList { get; } = new ReadOnlyCollection<Error>([NoErrors]);
+    public static ReadOnlyCollection<Error> CachedNoErrorsList { get; } = Array.AsReadOnly([NoErrors]);
 
-    public static ReadOnlyCollection<Error> CachedInvalidInitialErrorsList { get; } = new ReadOnlyCollection<Error>([EmptyInitialErrors]);
+    public static ReadOnlyCollection<Error> CachedInvalidInitialErrorsList { get; } = Array.AsReadOnly([EmptyInitialErrors]);
 
 #if NETSTANDARD
-    public static ReadOnlyCollection<Error> CachedEmptyErrorsList { get; } = new ReadOnlyCollection<Error>([]);
+    public static ReadOnlyCollection<Error> CachedEmptyErrorsList { get; } = Array.AsReadOnly<Error>([]);
 #else
     public static ReadOnlyCollection<Error> CachedEmptyErrorsList { get; } = ReadOnlyCollection<Error>.Empty;
 #endif

--- a/src/Errors/KnownErrors.cs
+++ b/src/Errors/KnownErrors.cs
@@ -14,9 +14,9 @@ internal static class KnownErrors
         code: "ErrorOr.EmptyInitialErrors",
         description: "Error list cannot be null or empty when initializing ErrorOr.");
 
-    public static List<Error> CachedNoErrorsList { get; } = new (1) { NoErrors };
+    public static ReadOnlyCollection<Error> CachedNoErrorsList { get; } = new ReadOnlyCollection<Error>([NoErrors]);
 
-    public static List<Error> CachedInvalidInitialErrorsList { get; } = new(1) { EmptyInitialErrors };
+    public static ReadOnlyCollection<Error> CachedInvalidInitialErrorsList { get; } = new ReadOnlyCollection<Error>([EmptyInitialErrors]);
 
-    public static List<Error> CachedEmptyErrorsList { get; } = new (0);
+    public static ReadOnlyCollection<Error> CachedEmptyErrorsList { get; } = new ReadOnlyCollection<Error>([]);
 }

--- a/tests/ErrorOr/ErrorOr.ElseAsyncTests.cs
+++ b/tests/ErrorOr/ErrorOr.ElseAsyncTests.cs
@@ -226,7 +226,7 @@ public class ElseAsyncTests
     }
 
     [Fact]
-    public async Task CallingElseAsyncWithErrorFunc_WhenIsError_ShouldReturnElseErrors()
+    public async Task CallingElseAsyncWithErrorsFunc_WhenIsError_ShouldReturnElseErrors()
     {
         // Arrange
         ErrorOr<string> errorOrString = Error.NotFound();
@@ -243,7 +243,7 @@ public class ElseAsyncTests
     }
 
     [Fact]
-    public async Task CallingElseAsyncWithErrorFunc_WhenIsSuccess_ShouldNotReturnElseErrors()
+    public async Task CallingElseAsyncWithErrorsFunc_WhenIsSuccess_ShouldNotReturnElseErrors()
     {
         // Arrange
         ErrorOr<string> errorOrString = "5";

--- a/tests/ErrorOr/ErrorOr.ElseAsyncTests.cs
+++ b/tests/ErrorOr/ErrorOr.ElseAsyncTests.cs
@@ -258,4 +258,63 @@ public class ElseAsyncTests
         result.IsError.Should().BeFalse();
         result.Value.Should().Be(errorOrString.Value);
     }
+
+    [Fact]
+    public async Task CallingElseAsyncWithErrorsFuncReturningList_WhenIsError_ShouldReturnElseErrors()
+    {
+        // Arrange
+        ErrorOr<string> errorOrString = Error.NotFound();
+
+        static Task ProcessErrorsAsync(ReadOnlyCollection<Error> errors)
+        {
+            // Simulate some asynchronous work with the errors
+            return Task.FromResult(errors);
+        }
+
+        // Act
+        ErrorOr<string> result = await errorOrString
+            .ElseAsync(async errors =>
+            {
+                List<Error> errorList = [Error.Unexpected()];
+                await ProcessErrorsAsync(errors);
+                foreach (var error in errors)
+                {
+                    errorList.Add(error);
+                }
+
+                return errorList;
+            });
+
+        // Assert
+        result.IsError.Should().BeTrue();
+        result.FirstError.Type.Should().Be(ErrorType.Unexpected);
+        result.Errors.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task CallingElseAsyncWithErrorsFuncReturningArray_WhenIsError_ShouldReturnElseErrors()
+    {
+        // Arrange
+        ErrorOr<string> errorOrString = Error.NotFound();
+
+        static Task ProcessErrorsAsync(ReadOnlyCollection<Error> errors)
+        {
+            // Simulate some asynchronous work with the errors
+            return Task.FromResult(errors);
+        }
+
+        // Act
+        ErrorOr<string> result = await errorOrString
+            .ElseAsync(async errors =>
+            {
+                Error[] errorArray = [Error.Unexpected(), .. errors];
+                await ProcessErrorsAsync(errors);
+                return errorArray;
+            });
+
+        // Assert
+        result.IsError.Should().BeTrue();
+        result.FirstError.Type.Should().Be(ErrorType.Unexpected);
+        result.Errors.Should().HaveCount(2);
+    }
 }

--- a/tests/ErrorOr/ErrorOr.ElseAsyncTests.cs
+++ b/tests/ErrorOr/ErrorOr.ElseAsyncTests.cs
@@ -1,4 +1,5 @@
 using ErrorOr;
+
 using FluentAssertions;
 
 namespace Tests;
@@ -234,7 +235,7 @@ public class ElseAsyncTests
         ErrorOr<string> result = await errorOrString
             .ThenAsync(Convert.ToIntAsync)
             .ThenAsync(Convert.ToStringAsync)
-            .ElseAsync(errors => Task.FromResult(new List<Error> { Error.Unexpected() }));
+            .ElseAsync(errors => Task.FromResult(new ReadOnlyCollection<Error>([Error.Unexpected()])));
 
         // Assert
         result.IsError.Should().BeTrue();
@@ -251,7 +252,7 @@ public class ElseAsyncTests
         ErrorOr<string> result = await errorOrString
             .ThenAsync(Convert.ToIntAsync)
             .ThenAsync(Convert.ToStringAsync)
-            .ElseAsync(errors => Task.FromResult(new List<Error> { Error.Unexpected() }));
+            .ElseAsync(errors => Task.FromResult(new ReadOnlyCollection<Error>([Error.Unexpected()])));
 
         // Assert
         result.IsError.Should().BeFalse();

--- a/tests/ErrorOr/ErrorOr.ElseTests.cs
+++ b/tests/ErrorOr/ErrorOr.ElseTests.cs
@@ -108,7 +108,7 @@ public class ElseTests
     }
 
     [Fact]
-    public void CallingElseWithErrorsFunc_WhenIsError_ShouldReturnElseError()
+    public void CallingElseWithErrorFunc_WhenIsError_ShouldReturnElseError()
     {
         // Arrange
         ErrorOr<string> errorOrString = Error.NotFound();
@@ -125,7 +125,7 @@ public class ElseTests
     }
 
     [Fact]
-    public void CallingElseWithErrorsFunc_WhenIsSuccess_ShouldNotReturnElseError()
+    public void CallingElseWithErrorFunc_WhenIsSuccess_ShouldNotReturnElseError()
     {
         // Arrange
         ErrorOr<string> errorOrString = "5";
@@ -283,7 +283,7 @@ public class ElseTests
     }
 
     [Fact]
-    public async Task CallingElseWithErrorFuncAfterThenAsync_WhenIsError_ShouldReturnElseErrors()
+    public async Task CallingElseWithErrorsFuncAfterThenAsync_WhenIsError_ShouldReturnElseErrors()
     {
         // Arrange
         ErrorOr<string> errorOrString = Error.NotFound();

--- a/tests/ErrorOr/ErrorOr.ElseTests.cs
+++ b/tests/ErrorOr/ErrorOr.ElseTests.cs
@@ -1,4 +1,5 @@
 using ErrorOr;
+
 using FluentAssertions;
 
 namespace Tests;
@@ -173,6 +174,51 @@ public class ElseTests
         // Assert
         result.IsError.Should().BeFalse();
         result.Value.Should().Be(errorOrString.Value);
+    }
+
+    [Fact]
+    public void CallingElseWithErrorsFuncReturningList_WhenIsError_ShouldReturnElseErrors()
+    {
+        // Arrange
+        ErrorOr<string> errorOrString = Error.NotFound();
+
+        // Act
+        ErrorOr<string> result = errorOrString
+            .Else(errors =>
+            {
+                List<Error> errorList = [Error.Unexpected()];
+                foreach (var error in errors)
+                {
+                    errorList.Add(error);
+                }
+
+                return errorList;
+            });
+
+        // Assert
+        result.IsError.Should().BeTrue();
+        result.FirstError.Type.Should().Be(ErrorType.Unexpected);
+        result.Errors.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void CallingElseWithErrorsFuncReturningArray_WhenIsError_ShouldReturnElseErrors()
+    {
+        // Arrange
+        ErrorOr<string> errorOrString = Error.NotFound();
+
+        // Act
+        ErrorOr<string> result = errorOrString
+            .Else(errors =>
+            {
+                Error[] errorArray = [Error.Unexpected(), .. errors];
+                return errorArray;
+            });
+
+        // Assert
+        result.IsError.Should().BeTrue();
+        result.FirstError.Type.Should().Be(ErrorType.Unexpected);
+        result.Errors.Should().HaveCount(2);
     }
 
     [Fact]

--- a/tests/ErrorOr/ErrorOr.EqualityTests.cs
+++ b/tests/ErrorOr/ErrorOr.EqualityTests.cs
@@ -1,4 +1,4 @@
-﻿using ErrorOr;
+using ErrorOr;
 using FluentAssertions;
 
 namespace Tests;

--- a/tests/ErrorOr/ErrorOr.ImmutabilityTests.cs
+++ b/tests/ErrorOr/ErrorOr.ImmutabilityTests.cs
@@ -1,0 +1,164 @@
+using ErrorOr;
+
+using FluentAssertions;
+
+namespace Tests;
+
+public class ErrorOrImmutabilityTests
+{
+    [Fact]
+    public void AdditionToUnderlyingErrorList_UsedToCreateErrorOr_ShouldNotAffectTheErrorOrInstance()
+    {
+        // Arrange
+        List<Error> errorList = [
+            Error.Validation("Validation.Error1", "Validation error 1"),
+            Error.Validation("Validation.Error2", "Validation error 2")
+        ];
+
+        ErrorOr<int> errorOrInt = errorList;
+
+        // Act
+        errorList.Add(Error.Validation("Validation.Error3", "Validation error 3")); // Adding an item to the original list should not affect the ErrorOr instance)
+
+        // Assert
+        errorOrInt.IsError.Should().BeTrue();
+        errorOrInt.Errors.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void AdditionToUnderlyingErrorList_UsedToCreateErrorOrFromReadOnlyCollection_ShouldNotAffectTheErrorOrInstance()
+    {
+        // Arrange
+        List<Error> errorList = [
+            Error.Validation("Validation.Error1", "Validation error 1"),
+            Error.Validation("Validation.Error2", "Validation error 2")
+        ];
+
+        ErrorOr<int> errorOrInt = errorList.AsReadOnly();
+
+        // Act
+        errorList.Add(Error.Validation("Validation.Error3", "Validation error 3")); // Adding an item to the original list should not affect the ErrorOr instance)
+
+        // Assert
+        errorOrInt.IsError.Should().BeTrue();
+        errorOrInt.Errors.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void ModificationToUnderlyingErrorList_UsedToCreateErrorOr_ShouldNotAffectTheErrorOrInstance()
+    {
+        // Arrange
+        List<Error> errorList = [
+            Error.Validation("Validation.Error1", "Validation error 1"),
+            Error.Validation("Validation.Error2", "Validation error 2")
+        ];
+
+        ErrorOr<int> errorOrInt = errorList;
+
+        // Act
+        errorList[1] = Error.Validation("Validation.Error3", "Validation error 3"); // Modifying an item of the original list should not affect the ErrorOr instance)
+
+        // Assert
+        errorOrInt.IsError.Should().BeTrue();
+        errorOrInt.Errors.Should().HaveCount(2);
+        errorOrInt.Errors[1].Should().BeEquivalentTo(Error.Validation("Validation.Error2", "Validation error 2")); // The second error should remain unchanged
+    }
+
+    [Fact]
+    public void ModificationToUnderlyingErrorList_UsedToCreateErrorOrFromReadOnlyCollection_ShouldNotAffectTheErrorOrInstance()
+    {
+        // Arrange
+        List<Error> errorList = [
+            Error.Validation("Validation.Error1", "Validation error 1"),
+            Error.Validation("Validation.Error2", "Validation error 2")
+        ];
+
+        ErrorOr<int> errorOrInt = errorList.AsReadOnly();
+
+        // Act
+        errorList[1] = Error.Validation("Validation.Error3", "Validation error 3"); // Modifying an item of the original list should not affect the ErrorOr instance)
+
+        // Assert
+        errorOrInt.IsError.Should().BeTrue();
+        errorOrInt.Errors.Should().HaveCount(2);
+        errorOrInt.Errors[1].Should().BeEquivalentTo(Error.Validation("Validation.Error2", "Validation error 2")); // The second error should remain unchanged
+    }
+
+    [Fact]
+    public void ModificationToUnderlyingErrorArray_UsedToCreateErrorOr_ShouldNotAffectTheErrorOrInstance()
+    {
+        // Arrange
+        Error[] errorArray = [
+            Error.Validation("Validation.Error1", "Validation error 1"),
+            Error.Validation("Validation.Error2", "Validation error 2")
+        ];
+
+        ErrorOr<int> errorOrInt = errorArray;
+
+        // Act
+        errorArray[1] = Error.Validation("Validation.Error3", "Validation error 3"); // Modifying an item of the original array should not affect the ErrorOr instance)
+
+        // Assert
+        errorOrInt.IsError.Should().BeTrue();
+        errorOrInt.Errors.Should().HaveCount(2);
+        errorOrInt.Errors[1].Should().BeEquivalentTo(Error.Validation("Validation.Error2", "Validation error 2")); // The second error should remain unchanged
+    }
+
+    [Fact]
+    public void ModificationToUnderlyingErrorArray_UsedToCreateErrorOrFromReadOnlyCollection_ShouldNotAffectTheErrorOrInstance()
+    {
+        // Arrange
+        Error[] errorArray = [
+            Error.Validation("Validation.Error1", "Validation error 1"),
+            Error.Validation("Validation.Error2", "Validation error 2")
+        ];
+
+        ErrorOr<int> errorOrInt = Array.AsReadOnly(errorArray);
+
+        // Act
+        errorArray[1] = Error.Validation("Validation.Error3", "Validation error 3"); // Modifying an item of the original array should not affect the ErrorOr instance)
+
+        // Assert
+        errorOrInt.IsError.Should().BeTrue();
+        errorOrInt.Errors.Should().HaveCount(2);
+        errorOrInt.Errors[1].Should().BeEquivalentTo(Error.Validation("Validation.Error2", "Validation error 2")); // The second error should remain unchanged
+    }
+
+    [Fact]
+    public void RemovalFromUnderlyingErrorList_UsedToCreateErrorOr_ShouldNotAffectTheErrorOrInstance()
+    {
+        // Arrange
+        List<Error> errorList = [
+            Error.Validation("Validation.Error1", "Validation error 1"),
+            Error.Validation("Validation.Error2", "Validation error 2")
+        ];
+
+        ErrorOr<int> errorOrInt = errorList;
+
+        // Act
+        errorList.RemoveAt(1); // Removing an item from the original list should not affect the ErrorOr instance)
+
+        // Assert
+        errorOrInt.IsError.Should().BeTrue();
+        errorOrInt.Errors.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void RemovalFromUnderlyingErrorList_UsedToCreateErrorOrFromReadOnlyCollection_ShouldNotAffectTheErrorOrInstance()
+    {
+        // Arrange
+        List<Error> errorList = [
+            Error.Validation("Validation.Error1", "Validation error 1"),
+            Error.Validation("Validation.Error2", "Validation error 2")
+        ];
+
+        ErrorOr<int> errorOrInt = errorList.AsReadOnly();
+
+        // Act
+        errorList.RemoveAt(1); // Removing an item from the original list should not affect the ErrorOr instance)
+
+        // Assert
+        errorOrInt.IsError.Should().BeTrue();
+        errorOrInt.Errors.Should().HaveCount(2);
+    }
+}

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -46,7 +46,7 @@ public class ErrorOrInstantiationTests
         ErrorOr<IEnumerable<string>> errorOrPerson = ErrorOrFactory.From(value);
 
         // Act
-        List<Error> errors = errorOrPerson.Errors;
+        ReadOnlyCollection<Error> errors = errorOrPerson.Errors;
 
         // Assert
         errors.Should().ContainSingle().Which.Type.Should().Be(ErrorType.Unexpected);
@@ -60,7 +60,7 @@ public class ErrorOrInstantiationTests
         ErrorOr<IEnumerable<string>> errorOrPerson = ErrorOrFactory.From(value);
 
         // Act
-        List<Error> errors = errorOrPerson.ErrorsOrEmptyList;
+        ReadOnlyCollection<Error> errors = errorOrPerson.ErrorsOrEmptyList;
 
         // Assert
         errors.Should().BeEmpty();
@@ -123,19 +123,6 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
-    [Obsolete]
-    public void CreateFromErrorList_WhenAccessingErrors_ShouldReturnErrorList()
-    {
-        // Arrange
-        List<Error> errors = [Error.Validation("User.Name", "Name is too short")];
-        ErrorOr<Person> errorOrPerson = ErrorOr<Person>.From(errors);
-
-        // Act & Assert
-        errorOrPerson.IsError.Should().BeTrue();
-        errorOrPerson.Errors.Should().ContainSingle().Which.Should().Be(errors.Single());
-    }
-
-    [Fact]
     public void CreateFromErrorList_UsingFactory_WhenAccessingErrorsOrEmptyList_ShouldReturnErrorList()
     {
         // Arrange
@@ -150,38 +137,10 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
-    [Obsolete]
-    public void CreateFromErrorList_WhenAccessingErrorsOrEmptyList_ShouldReturnErrorList()
-    {
-        // Arrange
-        List<Error> errors = [Error.Validation("User.Name", "Name is too short")];
-        ErrorOr<Person> errorOrPerson = ErrorOr<Person>.From(errors);
-
-        // Act & Assert
-        errorOrPerson.IsError.Should().BeTrue();
-        errorOrPerson.ErrorsOrEmptyList.Should().ContainSingle().Which.Should().Be(errors.Single());
-    }
-
-    [Fact]
     public void CreateFromErrorList_UsingFactory_WhenAccessingValue_ShouldReturnDefault()
     {
         // Arrange
         ErrorOr<Person> errorOrPerson = ErrorOrFactory.From<Person>([Error.Validation("User.Name", "Name is too short")]);
-
-        // Act
-        Person value = errorOrPerson.Value;
-
-        // Assert
-        value.Should().Be(default);
-    }
-
-    [Fact]
-    [Obsolete]
-    public void CreateFromErrorList_WhenAccessingValue_ShouldReturnDefault()
-    {
-        // Arrange
-        List<Error> errors = [Error.Validation("User.Name", "Name is too short")];
-        ErrorOr<Person> errorOrPerson = ErrorOr<Person>.From(errors);
 
         // Act
         Person value = errorOrPerson.Value;
@@ -262,7 +221,7 @@ public class ErrorOrInstantiationTests
         ErrorOr<Person> errorOrPerson = new Person("Amichai");
 
         // Act
-        List<Error> errors = errorOrPerson.Errors;
+        ReadOnlyCollection<Error> errors = errorOrPerson.Errors;
 
         // Assert
         errors.Should().ContainSingle().Which.Type.Should().Be(ErrorType.Unexpected);
@@ -479,7 +438,7 @@ public class ErrorOrInstantiationTests
         ErrorOr<int> errorOrInt = new ErrorOr<int>();
 
         // Act
-        List<Error> errors = errorOrInt.Errors;
+        ReadOnlyCollection<Error> errors = errorOrInt.Errors;
 
         // Assert
         errors.Should().ContainSingle().Which.Type.Should().Be(ErrorType.Unexpected);
@@ -492,7 +451,7 @@ public class ErrorOrInstantiationTests
         ErrorOr<int> errorOrInt = new ErrorOr<int>();
 
         // Act
-        List<Error> errors = errorOrInt.ErrorsOrEmptyList;
+        ReadOnlyCollection<Error> errors = errorOrInt.ErrorsOrEmptyList;
 
         // Assert
         errors.Should().BeEmpty();
@@ -530,7 +489,7 @@ public class ErrorOrInstantiationTests
         ErrorOr<int> errorOrInt = default;
 
         // Act
-        List<Error> errors = errorOrInt.Errors;
+        ReadOnlyCollection<Error> errors = errorOrInt.Errors;
 
         // Assert
         errors.Should().ContainSingle().Which.Type.Should().Be(ErrorType.Unexpected);
@@ -543,7 +502,7 @@ public class ErrorOrInstantiationTests
         ErrorOr<int> errorOrInt = default;
 
         // Act
-        List<Error> errors = errorOrInt.ErrorsOrEmptyList;
+        ReadOnlyCollection<Error> errors = errorOrInt.ErrorsOrEmptyList;
 
         // Assert
         errors.Should().BeEmpty();
@@ -644,7 +603,7 @@ public class ErrorOrInstantiationTests
         ErrorOr<int> errorOrInt = new List<Error>();
 
         // Act
-        List<Error> errors = errorOrInt.Errors;
+        ReadOnlyCollection<Error> errors = errorOrInt.Errors;
 
         // Assert
         errors.Should().ContainSingle().Which.Type.Should().Be(ErrorType.Unexpected);
@@ -657,7 +616,7 @@ public class ErrorOrInstantiationTests
         ErrorOr<int> errorOrInt = new List<Error>();
 
         // Act
-        List<Error> errors = errorOrInt.ErrorsOrEmptyList;
+        ReadOnlyCollection<Error> errors = errorOrInt.ErrorsOrEmptyList;
 
         // Assert
         errors.Should().ContainSingle().Which.Type.Should().Be(ErrorType.Unexpected);
@@ -703,7 +662,7 @@ public class ErrorOrInstantiationTests
         ErrorOr<int> errorOrInt = Array.Empty<Error>();
 
         // Act
-        List<Error> errors = errorOrInt.Errors;
+        ReadOnlyCollection<Error> errors = errorOrInt.Errors;
 
         // Assert
         errors.Should().ContainSingle().Which.Type.Should().Be(ErrorType.Unexpected);
@@ -716,7 +675,7 @@ public class ErrorOrInstantiationTests
         ErrorOr<int> errorOrInt = Array.Empty<Error>();
 
         // Act
-        List<Error> errors = errorOrInt.ErrorsOrEmptyList;
+        ReadOnlyCollection<Error> errors = errorOrInt.ErrorsOrEmptyList;
 
         // Assert
         errors.Should().ContainSingle().Which.Type.Should().Be(ErrorType.Unexpected);
@@ -766,7 +725,7 @@ public class ErrorOrInstantiationTests
         ErrorOr<int?> errorOrInt = default(int?);
 
         // Act
-        List<Error> errors = errorOrInt.Errors;
+        ReadOnlyCollection<Error> errors = errorOrInt.Errors;
 
         // Assert
         errors.Should().ContainSingle().Which.Type.Should().Be(ErrorType.Unexpected);
@@ -779,7 +738,7 @@ public class ErrorOrInstantiationTests
         ErrorOr<int?> errorOrInt = default(int?);
 
         // Act
-        List<Error> errors = errorOrInt.ErrorsOrEmptyList;
+        ReadOnlyCollection<Error> errors = errorOrInt.ErrorsOrEmptyList;
 
         // Assert
         errors.Should().BeEmpty();
@@ -802,7 +761,7 @@ public class ErrorOrInstantiationTests
     public void ImplicitCastNullErrorList_ShouldBeError()
     {
         // Arrange
-        ErrorOr<int> errorOrInt = default(List<Error>)!;
+        ErrorOr<int> errorOrInt = default(ReadOnlyCollection<Error>)!;
 
         // Act & Assert
         errorOrInt.IsError.Should().BeTrue();
@@ -812,7 +771,7 @@ public class ErrorOrInstantiationTests
     public void ImplicitCastNullErrorList_WhenAccessingValue_ShouldReturnDefault()
     {
         // Arrange
-        ErrorOr<int> errorOrInt = default(List<Error>)!;
+        ErrorOr<int> errorOrInt = default(ReadOnlyCollection<Error>)!;
 
         // Act & Assert
         errorOrInt.Value.Should().Be(default);
@@ -822,10 +781,10 @@ public class ErrorOrInstantiationTests
     public void ImplicitCastNullErrorList_WhenAccessingErrors_ShouldReturnUnexpected()
     {
         // Arrange
-        ErrorOr<int> errorOrInt = default(List<Error>)!;
+        ErrorOr<int> errorOrInt = default(ReadOnlyCollection<Error>)!;
 
         // Act
-        List<Error> errors = errorOrInt.Errors;
+        ReadOnlyCollection<Error> errors = errorOrInt.Errors;
 
         // Assert
         errors.Should().ContainSingle().Which.Type.Should().Be(ErrorType.Unexpected);
@@ -835,10 +794,10 @@ public class ErrorOrInstantiationTests
     public void ImplicitCastNullErrorList_WhenAccessingErrorsOrEmptyList_ShouldReturnUnexpected()
     {
         // Arrange
-        ErrorOr<int> errorOrInt = default(List<Error>)!;
+        ErrorOr<int> errorOrInt = default(ReadOnlyCollection<Error>)!;
 
         // Act
-        List<Error> errors = errorOrInt.ErrorsOrEmptyList;
+        ReadOnlyCollection<Error> errors = errorOrInt.ErrorsOrEmptyList;
 
         // Assert
         errors.Should().ContainSingle().Which.Type.Should().Be(ErrorType.Unexpected);
@@ -848,7 +807,7 @@ public class ErrorOrInstantiationTests
     public void ImplicitCastNullErrorList_WhenAccessingFirstError_ShouldReturnUnexpected()
     {
         // Arrange
-        ErrorOr<int> errorOrInt = default(List<Error>)!;
+        ErrorOr<int> errorOrInt = default(ReadOnlyCollection<Error>)!;
 
         // Act
         Error firstError = errorOrInt.FirstError;
@@ -884,7 +843,7 @@ public class ErrorOrInstantiationTests
         ErrorOr<int> errorOrInt = default(Error[])!;
 
         // Act
-        List<Error> errors = errorOrInt.Errors;
+        ReadOnlyCollection<Error> errors = errorOrInt.Errors;
 
         // Assert
         errors.Should().ContainSingle().Which.Type.Should().Be(ErrorType.Unexpected);
@@ -897,7 +856,7 @@ public class ErrorOrInstantiationTests
         ErrorOr<int> errorOrInt = default(Error[])!;
 
         // Act
-        List<Error> errors = errorOrInt.ErrorsOrEmptyList;
+        ReadOnlyCollection<Error> errors = errorOrInt.ErrorsOrEmptyList;
 
         // Assert
         errors.Should().ContainSingle().Which.Type.Should().Be(ErrorType.Unexpected);

--- a/tests/ErrorOr/ErrorOr.RecordableTests.cs
+++ b/tests/ErrorOr/ErrorOr.RecordableTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using ErrorOr;
 using FluentAssertions;
@@ -148,13 +148,13 @@ public class ErrorOrRecordableTests
     {
         public string SerializeValue<TValue>(TValue value) => JsonSerializer.Serialize(value, JsonOptions);
 
-        public string SerializeErrors(List<Error> errors) => JsonSerializer.Serialize(errors, JsonOptions);
+        public string SerializeErrors(ReadOnlyCollection<Error> errors) => JsonSerializer.Serialize(errors, JsonOptions);
     }
 
     private sealed class ErrorThrowingRecordingSerializer : IRecordingSerializer<string>
     {
         public string SerializeValue<TValue>(TValue value) => throw new NotImplementedException();
 
-        public string SerializeErrors(List<Error> errors) => throw new NotImplementedException();
+        public string SerializeErrors(ReadOnlyCollection<Error> errors) => throw new NotImplementedException();
     }
 }

--- a/tests/Errors/Error.EqualityTests.cs
+++ b/tests/Errors/Error.EqualityTests.cs
@@ -1,30 +1,32 @@
-﻿using ErrorOr;
+using ErrorOr;
 using FluentAssertions;
 
-namespace Tests;
+using Dict = System.Collections.Generic.Dictionary<string, object>;
+using ReadDict = System.Collections.ObjectModel.ReadOnlyDictionary<string, object>;
 
+namespace Tests;
 public sealed class ErrorEqualityTests
 {
-    public static readonly TheoryData<string, string, int, Dictionary<string, object>?> ValidData =
-        new ()
+    public static readonly TheoryData<string, string, int, ReadDict?> ValidData =
+        new()
         {
             { "CodeA", "DescriptionA", 1, null },
-            { "CodeB", "DescriptionB", 3215, new Dictionary<string, object> { { "foo", "bar" }, { "baz", "qux" } } },
+            { "CodeB", "DescriptionB", 3215, new (new Dict { { "foo", "bar" }, { "baz", "qux" } }) },
         };
 
     public static readonly TheoryData<Error, Error> DifferentInstances =
-        new ()
+        new()
         {
             { Error.Failure(), Error.Forbidden() },
-            { Error.NotFound(), Error.NotFound(metadata: new Dictionary<string, object> { ["Foo"] = "Bar" }) },
-            { Error.Unexpected(metadata: new Dictionary<string, object> { ["baz"] = "qux" }), Error.Unexpected() },
+            { Error.NotFound(), Error.NotFound(metadata: new ReadDict(new Dict { ["Foo"] = "Bar" })) },
+            { Error.Unexpected(metadata: new ReadDict(new Dict { ["baz"] = "qux" })), Error.Unexpected() },
             {
-                Error.Failure(metadata: new Dictionary<string, object> { ["baz"] = "qux" }),
-                Error.Failure(metadata: new Dictionary<string, object> { ["Foo"] = "Bar", ["baz"] = "qux" })
+                Error.Failure(metadata: new ReadDict(new Dict { ["baz"] = "qux" })),
+                Error.Failure(metadata: new ReadDict(new Dict { ["Foo"] = "Bar", ["baz"] = "qux" }))
             },
             {
-                Error.Failure(metadata: new Dictionary<string, object> { ["baz"] = "qux" }),
-                Error.Failure(metadata: new Dictionary<string, object> { ["baz"] = "gorge" })
+                Error.Failure(metadata: new ReadDict(new Dict { ["baz"] = "qux" })),
+                Error.Failure(metadata: new ReadDict(new Dict { ["baz"] = "gorge" }))
             },
         };
 
@@ -34,10 +36,10 @@ public sealed class ErrorEqualityTests
         string code,
         string description,
         int numericType,
-        Dictionary<string, object>? metadata)
+        ReadDict? metadata)
     {
         var error1 = Error.Custom(numericType, code, description, metadata);
-        var clonedDictionary = metadata is null ? null : new Dictionary<string, object>(metadata);
+        var clonedDictionary = metadata is null ? null : new ReadDict(new Dict(metadata));
         var error2 = Error.Custom(numericType, code, description, clonedDictionary);
 
         var result = error1.Equals(error2);
@@ -48,7 +50,7 @@ public sealed class ErrorEqualityTests
     [Fact]
     public void Equals_WhenTwoInstancesHaveTheSameMetadataInstanceAndPropertyValues_ShouldReturnTrue()
     {
-        var metadata = new Dictionary<string, object> { { "foo", "bar" } };
+        var metadata = new ReadDict(new Dict { { "foo", "bar" } });
         var error1 = Error.Custom(1, "Code", "Description", metadata);
         var error2 = Error.Custom(1, "Code", "Description", metadata);
 
@@ -72,10 +74,10 @@ public sealed class ErrorEqualityTests
         string code,
         string description,
         int numericType,
-        Dictionary<string, object>? metadata)
+        ReadDict? metadata)
     {
         var error1 = Error.Custom(numericType, code, description, metadata);
-        var clonedDictionary = metadata is null ? null : new Dictionary<string, object>(metadata);
+        var clonedDictionary = metadata is null ? null : new ReadDict(new Dict(metadata));
         var error2 = Error.Custom(numericType, code, description, clonedDictionary);
 
         var hashCode1 = error1.GetHashCode();

--- a/tests/Errors/Error.ImmutabilityTests.cs
+++ b/tests/Errors/Error.ImmutabilityTests.cs
@@ -1,0 +1,56 @@
+using ErrorOr;
+
+using FluentAssertions;
+
+namespace Tests;
+
+public class ErrorImmutabilityTests
+{
+    [Fact]
+    public void ModificationToUnderlyingErrorMetadataDictionary_UsedToCreateError_ShouldNotAffectTheErrorInstance()
+    {
+        // Arrange
+        var metadata = new Dictionary<string, object>
+        {
+            { "key1", "value1" },
+            { "key2", 21 },
+            { "key3", true },
+        };
+
+        var error = Error.Failure("ErrorCode", "ErrorDescription", metadata);
+
+        // Act
+        metadata["key1"] = "newValue";
+        metadata["key4"] = "value4";
+        metadata.Remove("key3");
+
+        // Assert
+        error.Metadata.Should().ContainKeys("key1", "key2", "key3");
+        error.Metadata.Should().NotContainKey("key4");
+        error.Metadata["key1"].Should().Be("value1");
+    }
+
+    [Fact]
+    public void ModificationToUnderlyingErrorMetadataDictionary_UsedToCreateErrorFromReadOnlyDictionary_ShouldNotAffectTheErrorInstance()
+    {
+        // Arrange
+        var metadata = new Dictionary<string, object>
+        {
+            { "key1", "value1" },
+            { "key2", 21 },
+            { "key3", true },
+        };
+
+        var error = Error.Failure("ErrorCode", "ErrorDescription", new ReadOnlyDictionary<string, object>(metadata));
+
+        // Act
+        metadata["key1"] = "newValue";
+        metadata["key4"] = "value4";
+        metadata.Remove("key3");
+
+        // Assert
+        error.Metadata.Should().ContainKeys("key1", "key2", "key3");
+        error.Metadata.Should().NotContainKey("key4");
+        error.Metadata["key1"].Should().Be("value1");
+    }
+}

--- a/tests/Errors/ErrorTests.cs
+++ b/tests/Errors/ErrorTests.cs
@@ -7,11 +7,12 @@ public class ErrorTests
 {
     private const string ErrorCode = "ErrorCode";
     private const string ErrorDescription = "ErrorDescription";
-    private static readonly Dictionary<string, object> Dictionary = new()
+    private static readonly ReadOnlyDictionary<string, object> Dictionary = new(
+    new Dictionary<string, object>
     {
         { "key1", "value1" },
         { "key2", 21 },
-    };
+    });
 
     [Fact]
     public void CreateError_WhenFailureError_ShouldHaveErrorTypeFailure()

--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Using Include="System.Collections.ObjectModel" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="fluentassertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="System.Text.Json" Condition="'$(TargetFramework)' == 'net462'" />


### PR DESCRIPTION
Hello!

I have read that there was already two attempts to make objects immutable: #9 and #26. I propose third solution: replacing `List<Error>` with `ReadOnlyCollection<Error>` in `ErrorOr.Errors` and `Dictionary<string, object>` with `ReadOnlyDictionary<string, object>` in `Error.Metadata` property.

It should not change much for existing code and does not have pitfall regarding lack of implicit conversion from interface. I was very focused not to break anything. I believe very conservative changes in unit tests proves that.