### PR TITLE
Fix NullReferenceException in ErrorOr<T>.GetHashCode for null values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- [#XXX](https://github.com/error-or/error-or/pull/XXX) Fixed `NullReferenceException` thrown by `ErrorOr<TValue>.GetHashCode()` when the instance is in a success state with a `null` value (including `default(ErrorOr<TValue>)` for reference types). The hash code is now computed via `EqualityComparer<TValue>.Default`, consistent with how `Equals` already handles `null`.
+
 ## [2.1.1] - 2026-05-15
 
 ### Added

--- a/src/ErrorOr/ErrorOr.Equality.cs
+++ b/src/ErrorOr/ErrorOr.Equality.cs
@@ -16,7 +16,7 @@ public readonly partial record struct ErrorOr<TValue>
     {
         if (IsSuccess)
         {
-            return _value.GetHashCode();
+            return EqualityComparer<TValue>.Default.GetHashCode(_value!);
         }
 
 #pragma warning disable SA1129 // HashCode needs to be instantiated this way

--- a/tests/ErrorOr/ErrorOr.EqualityTests.cs
+++ b/tests/ErrorOr/ErrorOr.EqualityTests.cs
@@ -143,6 +143,28 @@ public sealed class ErrorOrEqualityTests
     }
 
     [Fact]
+    public void GetHashCode_WhenValueIsNull_ShouldNotThrow()
+    {
+        ErrorOr<Person?> errorOrPerson = (Person?)null;
+
+        var act = () => errorOrPerson.GetHashCode();
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void GetHashCode_WhenBothValuesAreNull_ShouldReturnSameHashCode()
+    {
+        ErrorOr<Person?> errorOrPerson1 = (Person?)null;
+        ErrorOr<Person?> errorOrPerson2 = (Person?)null;
+
+        var hashCode1 = errorOrPerson1.GetHashCode();
+        var hashCode2 = errorOrPerson2.GetHashCode();
+
+        hashCode1.Should().Be(hashCode2);
+    }
+
+    [Fact]
     public void GetHashCode_WhenTwoInstancesHaveEqualErrors_ShouldReturnSameHashCode()
     {
         var errors1 = new[]


### PR DESCRIPTION
GetHashCode() called _value.GetHashCode() directly, which throws a NullReferenceException when an ErrorOr<T> is in a success state holding a null value. This also affects default(ErrorOr<T>) for reference types, since the default struct is a success state (_errors is null) whose value is null.

Equals() already treats null as a valid success value via EqualityComparer<TValue>.Default.Equals(...). GetHashCode() is now computed through the same comparer, restoring the Equals/GetHashCode contract so hash-based usage (HashSet, dictionary keys, Distinct, GroupBy) no longer throws.

Add regression tests covering null-valued and default-valued instances.